### PR TITLE
[FIX] improve room management flows and persist room rule edits

### DIFF
--- a/src/pages/ChatRoomPage.tsx
+++ b/src/pages/ChatRoomPage.tsx
@@ -74,6 +74,7 @@ const ChatRoomPage = () => {
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const fetchMembersRef = useRef<() => Promise<void>>(() => Promise.resolve())
   const markAsReadAndSyncRef = useRef<() => Promise<void>>(() => Promise.resolve())
+  const fetchMessagesRef = useRef<(opts?: { silent?: boolean }) => Promise<void>>(() => Promise.resolve())
   const messagesContainerRef = useRef<HTMLDivElement>(null)
   const myUserNoRef = useRef(myUserNo)
 
@@ -229,6 +230,7 @@ const ChatRoomPage = () => {
   // ref를 최신 함수로 동기화 (STOMP 클로저에서 stale 방지)
   useEffect(() => { fetchMembersRef.current = fetchMembers }, [fetchMembers])
   useEffect(() => { markAsReadAndSyncRef.current = markAsReadAndSync }, [markAsReadAndSync])
+  useEffect(() => { fetchMessagesRef.current = fetchMessages }, [fetchMessages])
 
   // 패널 열릴 때 멤버 목록 로드
   useEffect(() => {
@@ -274,11 +276,16 @@ const ChatRoomPage = () => {
         })
 
         client.subscribe(`/topic/chat-room/${chatRoomNo}/read`, () => {
-          void fetchMessages({ silent: true })
+          void fetchMessagesRef.current({ silent: true })
         })
 
         client.subscribe('/user/queue/notification', (msg: IMessage) => {
-          const notification: NotificationMessage = JSON.parse(msg.body)
+          let notification: NotificationMessage
+          try {
+            notification = JSON.parse(msg.body) as NotificationMessage
+          } catch {
+            return
+          }
 
           if (notification.chatRoomNo !== chatRoomNo) return
 
@@ -311,7 +318,7 @@ const ChatRoomPage = () => {
       client.deactivate()
       stompClientRef.current = null
     }
-  }, [chatRoomNo])
+  }, [chatRoomNo, appendMessage, updateRoomOnNewMessage, removeChatRoom, navigate])
 
   // showInfoPanel을 ref로 STOMP 콜백에서 최신 값 참조
   const showInfoPanelRef = useRef(showInfoPanel)

--- a/src/pages/ChatRoomPage.tsx
+++ b/src/pages/ChatRoomPage.tsx
@@ -5,10 +5,11 @@ import { Client } from '@stomp/stompjs'
 import type { IMessage } from '@stomp/stompjs'
 import SockJS from 'sockjs-client'
 import toast from 'react-hot-toast'
-import { ChevronLeft, Menu, X, LogOut, User, Users, Crown } from 'lucide-react'
+import { ChevronLeft, Menu, X, LogOut, User, Users, Crown, MoreHorizontal } from 'lucide-react'
 import MessageBubble from '@/components/chat/MessageBubble'
 import MessageInput from '@/components/chat/MessageInput'
 import { getChatMessages, markAsRead, leaveChatRoom, getChatRoomMembers } from '@/services/chatApi'
+import { kickRoommate } from '@/services/roomApi'
 import { useChatStore } from '@/store/chatStore'
 import { API_BASE_URL } from '@/utils/api'
 import apiClient from '@/services/apiClient'
@@ -18,6 +19,17 @@ interface RoomMember {
   userNo: string
   nickname: string
   isHost: boolean
+}
+
+interface RoomMemberWithRoomMeta extends RoomMember {
+  confirmStatus?: 'PENDING' | 'ACCEPTED' | 'COMPLETED'
+  isMe?: boolean
+}
+
+interface NotificationMessage {
+  type: 'KICKED_FROM_ROOM' | 'ROOM_DELETED'
+  roomNo: string
+  chatRoomNo: string
 }
 
 const ChatRoomPage = () => {
@@ -32,6 +44,7 @@ const ChatRoomPage = () => {
     prependMessages,
     appendMessage,
     updateRoomOnNewMessage,
+    removeChatRoom,
   } = useChatStore()
 
   const currentRoom = chatRooms.find(r => r.chatRoomNo === chatRoomNo)
@@ -50,13 +63,17 @@ const ChatRoomPage = () => {
   const [connected, setConnected] = useState(false)
   const [showInfoPanel, setShowInfoPanel] = useState(false)
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false)
-  const [members, setMembers] = useState<RoomMember[]>([])
+  const [members, setMembers] = useState<RoomMemberWithRoomMeta[]>([])
+  const [openMemberMenuUserNo, setOpenMemberMenuUserNo] = useState<string | null>(null)
+  const [roommateToKick, setRoommateToKick] = useState<RoomMemberWithRoomMeta | null>(null)
   const [isWideLayout, setIsWideLayout] = useState(false)
   const [containerRightOffset, setContainerRightOffset] = useState(0)
 
   const stompClientRef = useRef<Client | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  const fetchMembersRef = useRef<() => Promise<void>>(() => Promise.resolve())
+  const markAsReadAndSyncRef = useRef<() => Promise<void>>(() => Promise.resolve())
   const messagesContainerRef = useRef<HTMLDivElement>(null)
   const myUserNoRef = useRef(myUserNo)
 
@@ -81,6 +98,14 @@ const ChatRoomPage = () => {
   useEffect(() => {
     myUserNoRef.current = myUserNo
   }, [myUserNo])
+
+  useEffect(() => {
+    setMembers([])
+    setOpenMemberMenuUserNo(null)
+    setRoommateToKick(null)
+    setShowInfoPanel(false)
+    setShowLeaveConfirm(false)
+  }, [chatRoomNo])
 
   const fetchMessages = useCallback(async (options?: { silent?: boolean }) => {
     if (!chatRoomNo) return
@@ -152,19 +177,65 @@ const ChatRoomPage = () => {
   }, [])
 
   // 멤버 목록 조회
-  const fetchMembers = useCallback(() => {
-    if (!chatRoomNo || isDirect) return
-    getChatRoomMembers(chatRoomNo)
-      .then(res => setMembers(res.data))
-      .catch(() => { })
-  }, [chatRoomNo, isDirect])
+  const fetchMembers = useCallback(async () => {
+    if (!chatRoomNo || isDirect || !currentRoom?.roomNo) return
+
+    try {
+      const [chatMembersRes, roommatesRes] = await Promise.all([
+        getChatRoomMembers(chatRoomNo),
+        apiClient.get('/api/rooms/me/roommates'),
+      ])
+
+      const chatMembers = Array.isArray(chatMembersRes.data) ? chatMembersRes.data : []
+      const roommates = Array.isArray(roommatesRes.data) ? roommatesRes.data : []
+
+      const roommateMap = new Map(
+        roommates.map((mate: { userNo: string | number; confirmStatus?: string; isMe?: boolean }) => [
+          String(mate.userNo),
+          {
+            confirmStatus: mate.confirmStatus,
+            isMe: mate.isMe,
+          },
+        ])
+      )
+
+      const merged: RoomMemberWithRoomMeta[] = chatMembers.map((member: RoomMember) => {
+        const extra = roommateMap.get(String(member.userNo))
+        return {
+          ...member,
+          confirmStatus: extra?.confirmStatus as RoomMemberWithRoomMeta['confirmStatus'],
+          isMe: extra?.isMe,
+        }
+      })
+
+      setMembers(merged)
+    } catch {
+      // noop
+    }
+  }, [chatRoomNo, isDirect, currentRoom?.roomNo])
+
+  const amIHost = members.some((member) => member.userNo === myUserNo && member.isHost)
+  const isRoomCompleted = members.length > 0 && members.every(
+    (member) => member.confirmStatus === 'COMPLETED'
+  )
+
+  const canKickMember = (member: RoomMemberWithRoomMeta) =>
+    amIHost &&
+    !isRoomCompleted &&
+    !member.isMe &&
+    !member.isHost &&
+    currentRoom?.chatRoomType === 'GROUP'
+
+  // ref를 최신 함수로 동기화 (STOMP 클로저에서 stale 방지)
+  useEffect(() => { fetchMembersRef.current = fetchMembers }, [fetchMembers])
+  useEffect(() => { markAsReadAndSyncRef.current = markAsReadAndSync }, [markAsReadAndSync])
 
   // 패널 열릴 때 멤버 목록 로드
   useEffect(() => {
     if (showInfoPanel && !isDirect) {
-      fetchMembers()
+      void fetchMembers()
     }
-  }, [showInfoPanel])
+  }, [showInfoPanel, isDirect, fetchMembers])
 
   // STOMP 연결
   useEffect(() => {
@@ -182,13 +253,13 @@ const ChatRoomPage = () => {
           updateRoomOnNewMessage(chatRoomNo, message)
 
           // 시스템 메시지(입장/퇴장)이면 멤버 목록 갱신
-          if (message.messageType === 'SYSTEM' && showInfoPanelRef.current && !isDirect) {
-            fetchMembers()
+          if (message.messageType === 'SYSTEM' && showInfoPanelRef.current) {
+            void fetchMembersRef.current()
           }
 
           // 채팅방을 보고 있는 중이면 즉시 읽음 처리
           if (document.visibilityState === 'visible') {
-            void markAsReadAndSync()
+            void markAsReadAndSyncRef.current()
           }
 
           // 하단 근처에 있을 때만 자동 스크롤
@@ -204,6 +275,25 @@ const ChatRoomPage = () => {
 
         client.subscribe(`/topic/chat-room/${chatRoomNo}/read`, () => {
           void fetchMessages({ silent: true })
+        })
+
+        client.subscribe('/user/queue/notification', (msg: IMessage) => {
+          const notification: NotificationMessage = JSON.parse(msg.body)
+
+          if (notification.chatRoomNo !== chatRoomNo) return
+
+          if (notification.type === 'KICKED_FROM_ROOM') {
+            removeChatRoom(notification.chatRoomNo)
+            toast.error('방에서 강퇴되었습니다.')
+            navigate('/rooms/search')
+            return
+          }
+
+          if (notification.type === 'ROOM_DELETED') {
+            removeChatRoom(notification.chatRoomNo)
+            toast.error('방이 삭제되었습니다.')
+            navigate('/rooms/search')
+          }
         })
 
         client.subscribe('/user/queue/errors', (msg: IMessage) => {
@@ -293,6 +383,7 @@ const ChatRoomPage = () => {
     if (!chatRoomNo) return
     try {
       await leaveChatRoom(chatRoomNo)
+      removeChatRoom(chatRoomNo)
       toast.success('채팅방을 나갔습니다.')
       navigate('/chats')
     } catch (e: unknown) {
@@ -305,6 +396,29 @@ const ChatRoomPage = () => {
     } finally {
       setShowLeaveConfirm(false)
       setShowInfoPanel(false)
+    }
+  }
+
+  const handleKickFromChatPanel = async () => {
+    if (!currentRoom?.roomNo || !roommateToKick) return
+
+    try {
+      await kickRoommate(String(currentRoom.roomNo), roommateToKick.userNo)
+      toast.success(`${roommateToKick.nickname}님을 내보냈습니다.`)
+      setRoommateToKick(null)
+      setOpenMemberMenuUserNo(null)
+      void fetchMembers()
+    } catch (e: unknown) {
+      const code = (e as { response?: { data?: { code?: string } } })?.response?.data?.code
+      if (code === 'ROOM005') {
+        toast.error('방장만 룸메이트를 내보낼 수 있습니다.')
+      } else if (code === 'ROOM009') {
+        toast.error('룸메이트를 찾을 수 없습니다.')
+      } else if (code === 'ROOM012') {
+        toast.error('자기 자신은 내보낼 수 없습니다.')
+      } else {
+        toast.error('내보내기에 실패했습니다.')
+      }
     }
   }
 
@@ -449,19 +563,49 @@ const ChatRoomPage = () => {
                   </p>
                   <div className="flex flex-col gap-2">
                     {members.map(member => (
-                      <div key={member.userNo} className="flex items-center gap-3">
-                        <div className="w-9 h-9 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
-                          <User className="w-4 h-4 text-gray-500" />
+                      <div key={member.userNo} className="flex items-center justify-between gap-3">
+                        <div className="flex items-center gap-3 min-w-0">
+                          <div className="w-9 h-9 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+                            <User className="w-4 h-4 text-gray-500" />
+                          </div>
+                          <div className="flex items-center gap-1.5 min-w-0">
+                            <span className="text-sm font-medium text-gray-900 truncate">{member.nickname}</span>
+                            {member.isHost && (
+                              <Crown className="w-3.5 h-3.5 text-yellow-500 flex-shrink-0" />
+                            )}
+                            {member.userNo === myUserNo && (
+                              <span className="text-xs text-gray-400 flex-shrink-0">(나)</span>
+                            )}
+                          </div>
                         </div>
-                        <div className="flex items-center gap-1.5 min-w-0">
-                          <span className="text-sm font-medium text-gray-900 truncate">{member.nickname}</span>
-                          {member.isHost && (
-                            <Crown className="w-3.5 h-3.5 text-yellow-500 flex-shrink-0" />
-                          )}
-                          {member.userNo === myUserNo && (
-                            <span className="text-xs text-gray-400 flex-shrink-0">(나)</span>
-                          )}
-                        </div>
+
+                        {canKickMember(member) && (
+                          <div className="relative">
+                            <button
+                              onClick={() =>
+                                setOpenMemberMenuUserNo((prev) => (prev === member.userNo ? null : member.userNo))
+                              }
+                              className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-500"
+                              aria-label="멤버 관리"
+                            >
+                              <MoreHorizontal className="w-4 h-4" />
+                            </button>
+
+                            {openMemberMenuUserNo === member.userNo && (
+                              <div className="absolute right-0 top-9 z-10 min-w-[7rem] bg-white border border-gray-200 rounded-xl shadow-lg p-1">
+                                <button
+                                  onClick={() => {
+                                    setRoommateToKick(member)
+                                    setOpenMemberMenuUserNo(null)
+                                  }}
+                                  className="w-full text-left px-3 py-2 text-sm font-medium text-red-600 hover:bg-red-50 rounded-lg"
+                                >
+                                  내보내기
+                                </button>
+                              </div>
+                            )}
+                          </div>
+                        )}
                       </div>
                     ))}
                   </div>
@@ -501,6 +645,32 @@ const ChatRoomPage = () => {
             </div>
           </div>
         </>
+      )}
+
+      {roommateToKick && (
+        <div className="fixed inset-0 bg-black/40 z-[60] flex items-center justify-center">
+          <div className="bg-white rounded-2xl p-6 max-w-sm mx-4 shadow-xl">
+            <h3 className="text-lg font-bold text-gray-900 mb-2">룸메이트 내보내기</h3>
+            <p className="text-sm text-gray-600 mb-6">
+              <span className="font-semibold text-gray-900">{roommateToKick.nickname}</span>님을 내보내시겠습니까?<br />
+              방이 최종 확정된 뒤에는 내보낼 수 없습니다.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setRoommateToKick(null)}
+                className="flex-1 px-4 py-3 text-sm font-semibold text-gray-700 bg-gray-100 rounded-xl hover:bg-gray-200 transition-colors"
+              >
+                취소
+              </button>
+              <button
+                onClick={() => void handleKickFromChatPanel()}
+                className="flex-1 px-4 py-3 text-sm font-semibold text-white bg-red-500 rounded-xl hover:bg-red-600 transition-colors"
+              >
+                내보내기
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/src/pages/MyRoomPage.tsx
+++ b/src/pages/MyRoomPage.tsx
@@ -1,15 +1,23 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Bell, Share2, Pencil, Settings, DoorOpen, CheckCircle, Star } from 'lucide-react'
+import { Bell, Share2, Pencil, Settings, DoorOpen, CheckCircle, Star, Trash2 } from 'lucide-react'
 import BottomNavigationBar from '../components/ui/BottomNavigationBar'
 import SectionLoading from '../components/ui/SectionLoading'
 import GuestOnlyMessage from '../components/ui/GuestOnlyMessage'
 import { getApiUrl } from '../utils/api'
-import { getOrCreateDirectChatRoom } from '@/services/chatApi'
+import { getOrCreateDirectChatRoom, findMyGroupChatRoomByRoomNo, leaveChatRoom } from '@/services/chatApi'
 import toast from 'react-hot-toast'
+import { kickRoommate, deleteRoom } from '@/services/roomApi'
+import { useChatStore } from '@/store/chatStore'
+import {
+  buildRoomRuleFetchPath,
+  normalizeRoomRuleTimeValue,
+  selectSingleOption,
+} from './myRoomRuleUtils'
 
 const MyRoomPage = () => {
   const navigate = useNavigate()
+  const { removeGroupChatRoomsByRoomNo } = useChatStore()
   type ApiRoom = {
     roomNo: number | string  // 백엔드에서 ToStringSerializer로 문자열로 직렬화될 수 있음
     roomType: string
@@ -92,6 +100,13 @@ const MyRoomPage = () => {
   const [activeTab, setActiveTab] = useState<'규칙' | '지원자' | '룸메이트'>('규칙')
   const [roommates, setRoommates] = useState<ApiRoommate[]>([])
   const isHost = useMemo(() => roommates.some((m) => m.isMe && m.roomRole === 'HOST'), [roommates])
+
+  useEffect(() => {
+    if (!isHost && activeTab === '지원자') {
+      setActiveTab('규칙')
+    }
+  }, [isHost, activeTab])
+
   const [roommatesLoading, setRoommatesLoading] = useState(true)
   const [isEditingChecklist, setIsEditingChecklist] = useState(false)
   const [isEditingTitle, setIsEditingTitle] = useState(false)
@@ -122,6 +137,7 @@ const MyRoomPage = () => {
   const [applicantChecklists, setApplicantChecklists] = useState<Record<string, ChecklistSection[]>>({}) // userNo를 키로 사용
   const [applicantOtherNotes, setApplicantOtherNotes] = useState<Record<string, string>>({}) // userNo를 키로 사용
   const [showConfirmAssignment, setShowConfirmAssignment] = useState(false) // 방 배정 확정 확인
+  const [showDeleteRoomConfirm, setShowDeleteRoomConfirm] = useState(false)
   const [otherNotes, setOtherNotes] = useState('')
   const [checklistSections, setChecklistSections] = useState<ChecklistSection[]>([])
 
@@ -186,14 +202,6 @@ const MyRoomPage = () => {
   useEffect(() => {
     const fetchMyRoom = async () => {
       try {
-        const isLoggedIn = !!localStorage.getItem('isLoggedIn')
-        if (!isLoggedIn) {
-          setIsGuest(true)
-          setLoading(false)
-          return
-        }
-        setIsGuest(false)
-
         // 1) CheckMyRoom 먼저 호출 - 방 없으면 LoadMyRoom 호출하지 않음
         const existsRes = await fetch(getApiUrl('/api/rooms/me/exists'), {
           credentials: 'include',
@@ -204,6 +212,8 @@ const MyRoomPage = () => {
           setLoading(false)
           return
         }
+
+        setIsGuest(false)
 
         const existsRawBody = await existsRes.text()
         let existsData: any
@@ -270,7 +280,7 @@ const MyRoomPage = () => {
 
     const fetchRoomRule = async () => {
       try {
-        const res = await fetch(getApiUrl(`/api/rooms/${effectiveRoomNo}/rule`), {
+        const res = await fetch(getApiUrl(buildRoomRuleFetchPath(effectiveRoomNo)), {
           credentials: 'include',
         })
 
@@ -1011,22 +1021,15 @@ const MyRoomPage = () => {
       prev.map((section, sIdx) => {
         if (sIdx !== sectionIndex) return section
         
-        // 추가 규칙 섹션인지 확인
-        const isAdditionalRules = section.category === 'ADDITIONAL_RULES'
-        
         return {
           ...section,
           items: section.items.map((item, iIdx) => {
             if (iIdx !== itemIndex || !item.options) return item
             
-            // 추가 규칙이면 토글 방식, 아니면 단일 선택 방식
-            if (isAdditionalRules) {
+            if (section.category === 'ADDITIONAL_RULES') {
               return {
                 ...item,
-                options: item.options.map((option, oIdx) => ({
-                  ...option,
-                  selected: oIdx === optionIndex ? !option.selected : option.selected,
-                })),
+                options: selectSingleOption(item.options, optionIndex),
               }
             } else {
               return {
@@ -1048,16 +1051,144 @@ const MyRoomPage = () => {
     [room]
   )
   const displayCapacity = room ? `${room.capacity}인실` : ''
-  const displayMembers = room ? `${roommates.length}/${room.capacity}명` : ''
+  const displayMembers = room ? `${room.currentMateCount}/${room.capacity}명` : ''
   const displayStatus = room ? mapApiStatusToDisplay(room.roomStatus) : ''
   // const displayCreatedAt = room ? formatRelativeTime(room.createdAt) : '' // 사용되지 않음
   const displayResidencePeriod = room ? mapResidencePeriodToDisplay(room.residencePeriod) : ''
   
+  const handleKickRoommate = async () => {
+    if (!roommateToRemove || !room?.roomNo) return
+
+    const roomNo = String(room.roomNo)
+    const target = roommates.find((mate) => mate.roommateNo === roommateToRemove.roommateNo)
+
+    if (!target) {
+      toast.error('내보낼 룸메이트 정보를 찾을 수 없습니다.')
+      setRoommateToRemove(null)
+      return
+    }
+
+    if (room.roomStatus === 'COMPLETED') {
+      toast.error('방이 최종 확정된 후에는 내보낼 수 없습니다.')
+      setRoommateToRemove(null)
+      setShowRoommateSettings(false)
+      return
+    }
+
+    try {
+      await kickRoommate(roomNo, String(target.userNo))
+      toast.success(`${roommateToRemove.name}님을 내보냈습니다.`)
+      setRoommates((prev) => prev.filter((mate) => mate.roommateNo !== roommateToRemove.roommateNo))
+      setRoom((prev) =>
+        prev
+          ? {
+              ...prev,
+              currentMateCount: Math.max(0, prev.currentMateCount - 1),
+            }
+          : prev
+      )
+      setRoommateToRemove(null)
+      setShowRoommateSettings(false)
+    } catch (e: unknown) {
+      const code = (e as { response?: { data?: { code?: string } } })?.response?.data?.code
+      if (code === 'ROOM005') {
+        toast.error('방장만 룸메이트를 내보낼 수 있습니다.')
+      } else if (code === 'ROOM009') {
+        toast.error('룸메이트를 찾을 수 없습니다.')
+      } else if (code === 'ROOM012') {
+        toast.error('자기 자신은 내보낼 수 없습니다.')
+      } else {
+        toast.error('내보내기에 실패했습니다.')
+      }
+    }
+  }
+
+  const handleLeaveRoom = async () => {
+    if (!room?.roomNo) return
+
+    const roomNo = String(room.roomNo)
+
+    try {
+      const groupChatRoom = await findMyGroupChatRoomByRoomNo(roomNo)
+
+      if (!groupChatRoom?.chatRoomNo) {
+        if (isHost && roommates.length === 1) {
+          await deleteRoom(roomNo)
+          removeGroupChatRoomsByRoomNo(roomNo)
+          toast.success('방이 삭제되었습니다.')
+          setShowLeaveConfirm(false)
+          navigate('/rooms/search', { state: { refreshRooms: true } })
+          return
+        }
+
+        toast.error('연결된 채팅방을 찾을 수 없습니다.')
+        setShowLeaveConfirm(false)
+        return
+      }
+
+      await leaveChatRoom(groupChatRoom.chatRoomNo)
+      removeGroupChatRoomsByRoomNo(roomNo)
+      toast.success('방에서 나갔습니다.')
+      setShowLeaveConfirm(false)
+      navigate('/rooms/search', { state: { deletedRoomNo: roomNo, refreshRooms: true } })
+    } catch (e: unknown) {
+      const code = (e as { response?: { data?: { code?: string } } })?.response?.data?.code
+
+      if (code === 'CHAT005' || code === 'HOST_CANNOT_LEAVE') {
+        toast.error('다른 멤버가 있는 경우 방장은 방을 나갈 수 없습니다.')
+      } else {
+        toast.error('방 나가기에 실패했습니다.')
+      }
+
+      setShowLeaveConfirm(false)
+    }
+  }
+
+  const handleDeleteRoom = async () => {
+    if (!room?.roomNo) return
+
+    const roomNo = String(room.roomNo)
+
+    try {
+      await deleteRoom(roomNo)
+      removeGroupChatRoomsByRoomNo(roomNo)
+      toast.success('방이 삭제되었습니다.')
+      setShowDeleteRoomConfirm(false)
+      navigate('/rooms/search', { state: { refreshRooms: true } })
+    } catch (e: unknown) {
+      const code = (e as { response?: { data?: { code?: string } } })?.response?.data?.code
+
+      if (code === 'ROOM005') {
+        toast.error('방장만 방을 삭제할 수 있습니다.')
+      } else if (code === 'ROOM017') {
+        toast.error('다른 룸메이트가 있으면 방을 삭제할 수 없습니다.')
+      } else if (code === 'ROOM018') {
+        toast.error('확정된 방은 삭제할 수 없습니다.')
+      } else {
+        toast.error('방 삭제에 실패했습니다.')
+      }
+
+      setShowDeleteRoomConfirm(false)
+    }
+  }
+
   // 자신의 confirmStatus 찾기
   const myConfirmStatus = useMemo(() => {
     const myRoommate = roommates.find(mate => mate.isMe)
     return myRoommate?.confirmStatus || null
   }, [roommates])
+
+  const otherRoommates = roommates.filter((mate) => !mate.isMe)
+
+  const allOtherRoommatesConfirmed = otherRoommates.every(
+    (mate) => mate.confirmStatus === 'ACCEPTED' || mate.confirmStatus === 'COMPLETED'
+  )
+
+  const canOpenConfirmModal = (() => {
+    if (!room || myConfirmStatus === 'COMPLETED' || myConfirmStatus === 'ACCEPTED') return false
+    if (!isHost) return true
+    return allOtherRoommatesConfirmed
+  })()
 
   return (
     <div className="page-with-bottom-nav h-screen bg-white flex flex-col overflow-hidden animate-fade-in">
@@ -1175,13 +1306,24 @@ const MyRoomPage = () => {
                 </>
               )}
             </div>
-            <span className={`text-xs px-2 py-1 rounded-md font-semibold whitespace-nowrap ${
-              room?.roomStatus === 'COMPLETED'
-                ? 'bg-green-50 text-green-600 border border-green-200'
-                : 'bg-blue-50 text-blue-600 border border-blue-200'
-            }`}>
-              {displayStatus}
-            </span>
+            <div className="flex items-center gap-2">
+              <span className={`text-xs px-2 py-1 rounded-md font-semibold whitespace-nowrap ${
+                room?.roomStatus === 'COMPLETED'
+                  ? 'bg-green-50 text-green-600 border border-green-200'
+                  : 'bg-blue-50 text-blue-600 border border-blue-200'
+              }`}>
+                {displayStatus}
+              </span>
+              {isHost && room?.roomStatus !== 'COMPLETED' && (
+                <button
+                  onClick={() => setShowDeleteRoomConfirm(true)}
+                  className="p-1 hover:bg-red-50 text-red-400 hover:text-red-500 rounded transition-colors"
+                  title="방 삭제"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              )}
+            </div>
           </div>
           <div className="text-sm text-gray-600 mb-1">
             <div className="flex items-center space-x-1">
@@ -1214,28 +1356,35 @@ const MyRoomPage = () => {
               초대 링크
             </button>
             <button
-              onClick={() => myConfirmStatus !== 'ACCEPTED' && myConfirmStatus !== 'COMPLETED' && setShowConfirmAssignment(true)}
-              disabled={myConfirmStatus === 'ACCEPTED' || myConfirmStatus === 'COMPLETED'}
+              onClick={() => canOpenConfirmModal && setShowConfirmAssignment(true)}
+              disabled={!canOpenConfirmModal}
               className={`flex-1 rounded-lg py-2 text-sm font-medium flex items-center justify-center gap-2 transition-colors ${
                 myConfirmStatus === 'COMPLETED'
                   ? 'bg-green-50 text-green-600 border border-green-200 cursor-default'
-                  : myConfirmStatus === 'ACCEPTED'
-                    ? 'bg-[#3072E1] text-white border border-[#3072E1] cursor-not-allowed opacity-60'
-                    : 'bg-blue-50 text-blue-600 border border-blue-200 hover:bg-blue-100'
+                  : !canOpenConfirmModal
+                    ? 'bg-gray-100 text-gray-400 border border-gray-200 cursor-not-allowed'
+                    : myConfirmStatus === 'ACCEPTED'
+                      ? 'bg-[#3072E1] text-white border border-[#3072E1] cursor-not-allowed opacity-60'
+                      : 'bg-blue-50 text-blue-600 border border-blue-200 hover:bg-blue-100'
               }`}
             >
               <CheckCircle className="w-4 h-4" />
-              방 배정 확정
+              {isHost ? '최종 확정' : '방 배정 확정'}
             </button>
           </div>
+          {isHost && room?.roomStatus !== 'COMPLETED' && !allOtherRoommatesConfirmed && (
+            <p className="mt-2 text-xs text-amber-600">
+              다른 룸메이트가 모두 확정한 뒤 방장이 마지막으로 최종 확정할 수 있습니다.
+            </p>
+          )}
         </div>
 
         {/* 탭 */}
         <div className="flex justify-between text-sm text-gray-500 mt-4">
-          {(['규칙', '지원자', '룸메이트'] as const).map((tab) => (
+          {(['규칙', ...(isHost ? ['지원자'] : []), '룸메이트'] as const).map((tab) => (
             <button
               key={tab}
-              onClick={() => setActiveTab(tab)}
+              onClick={() => setActiveTab(tab as '규칙' | '지원자' | '룸메이트')}
               className={`flex-1 py-3 ${
                 activeTab === tab ? 'text-blue-600 border-b-2 border-blue-600' : ''
               }`}
@@ -1255,6 +1404,7 @@ const MyRoomPage = () => {
                 <h4 className="text-base font-bold text-black">{section.title}</h4>
                 {index === 0 && isHost && (
                   <button
+                    type="button"
                     className="flex items-center gap-1 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg px-2 py-1"
                     onClick={async () => {
                       if (!isEditingChecklist) {
@@ -1274,13 +1424,13 @@ const MyRoomPage = () => {
                       )
 
                       if (hasFixedArrivalWithoutTime) {
-                        // toast.error('귀가 시간을 선택해 주세요.')
+                        toast.error('귀가 시간을 선택해 주세요.')
                         return
                       }
 
                       // API 호출
                       if (!room?.roomNo) {
-                        // toast.error('방 정보를 불러올 수 없습니다.')
+                        toast.error('방 정보를 불러올 수 없습니다.')
                         return
                       }
 
@@ -1292,8 +1442,8 @@ const MyRoomPage = () => {
                         const residencePeriodItem = basicInfoSection?.items.find(item => item.label === '거주기간')
                         
                         const selectedCapacity = capacityItem?.options?.find(opt => opt.selected)?.text.replace('명', '')
-                        const capacity = selectedCapacity ? Number(selectedCapacity) : null
-                        
+                        const capacity = selectedCapacity ? Number(selectedCapacity) : (room.capacity ?? null)
+
                         const selectedDorm = dormItem?.options?.find(opt => opt.selected)?.text
                         const mapDormToRoomType = (dorm: string) => {
                           switch (dorm) {
@@ -1307,8 +1457,8 @@ const MyRoomPage = () => {
                               return null
                           }
                         }
-                        const roomType = selectedDorm ? mapDormToRoomType(selectedDorm) : null
-                        
+                        const roomType = selectedDorm ? mapDormToRoomType(selectedDorm) : (room.roomType ?? null)
+
                         // 거주기간 문자열을 enum 값으로 변환
                         const mapResidencePeriodToEnum = (period: string): string | null => {
                           switch (period) {
@@ -1323,7 +1473,7 @@ const MyRoomPage = () => {
                           }
                         }
                         const selectedResidencePeriod = residencePeriodItem?.options?.find(opt => opt.selected)?.text
-                        const residencePeriod = selectedResidencePeriod ? mapResidencePeriodToEnum(selectedResidencePeriod) : null
+                        const residencePeriod = selectedResidencePeriod ? mapResidencePeriodToEnum(selectedResidencePeriod) : (room.residencePeriod ?? null)
 
                         // Enum 매핑 함수들 (CreateRoomModal과 동일)
                         const mapReturnHome = (text: string): string => {
@@ -1473,7 +1623,7 @@ const MyRoomPage = () => {
                           bedtime: getItemValue('취침'),
                           wakeUp: getItemValue('기상'),
                           returnHome: mapReturnHome(getSelectedOption('귀가') || ''),
-                          returnHomeTime: getExtraValue('귀가'),
+                          returnHomeTime: normalizeRoomRuleTimeValue(getExtraValue('귀가')),
                           cleaning: mapCleaning(getSelectedOption('청소') || ''),
                           phoneCall: mapPhoneCall(getSelectedOption('방에서 전화') || ''),
                           sleepLight: mapSleepLight(getSelectedOption('잠귀') || ''),
@@ -1482,7 +1632,7 @@ const MyRoomPage = () => {
                           showerTime: mapShowerTime(getSelectedOption('샤워시간') || ''),
                           eating: mapEating(getSelectedOption('방에서 취식') || ''),
                           lightsOut: mapLightsOut(getSelectedOption('소등') || ''),
-                          lightsOutTime: getExtraValue('소등'),
+                          lightsOutTime: normalizeRoomRuleTimeValue(getExtraValue('소등')),
                           homeVisit: mapHomeVisit(getSelectedOption('본가 주기') || ''),
                           smoking: mapSmoking(getSelectedOption('흡연') || ''),
                           refrigerator: mapRefrigerator(getSelectedOption('냉장고') || ''),
@@ -1505,10 +1655,10 @@ const MyRoomPage = () => {
                             'Content-Type': 'application/json',
                           },
                           body: JSON.stringify({
-                            rule,
-                            roomType: roomType || null,
-                            capacity: capacity || null,
-                            residencePeriod: residencePeriod || null,
+                            ...rule,
+                            roomType,
+                            capacity,
+                            residencePeriod,
                           }),
                         })
 
@@ -1529,7 +1679,7 @@ const MyRoomPage = () => {
                           throw new Error('방 규칙 수정에 실패했습니다.')
                         }
 
-                        // toast.success('방 규칙이 수정되었습니다.')
+                        toast.success('방 규칙이 수정되었습니다.')
                         setIsEditingChecklist(false)
                         // 방 정보가 변경되었으면 다시 불러오기
                         if (capacity || roomType) {
@@ -1537,8 +1687,7 @@ const MyRoomPage = () => {
                         } else {
                           // capacity나 roomType이 변경되지 않았어도 RoomRule은 다시 불러와야 함
                           const effectiveRoomNo = String(room.roomNo)
-                          const params = new URLSearchParams({ roomNo: effectiveRoomNo })
-                          const refreshRes = await fetch(getApiUrl(`/api/rooms/me/rule?${params.toString()}`), {
+                          const refreshRes = await fetch(getApiUrl(buildRoomRuleFetchPath(effectiveRoomNo)), {
                             credentials: 'include',
                           })
                           if (refreshRes.ok) {
@@ -1557,7 +1706,8 @@ const MyRoomPage = () => {
                         }
                       } catch (err) {
                         console.error('[rooms] update rule error', err)
-                        // toast.error('방 규칙 수정에 실패했습니다.')
+                        toast.error('방 규칙 수정에 실패했습니다.')
+                        setIsEditingChecklist(false)
                       }
                     }}
                   >
@@ -1820,12 +1970,10 @@ const MyRoomPage = () => {
                         [applicant.userNo]: sections,
                       }))
 
-                      if (payload.otherNotes) {
-                        setApplicantOtherNotes((prev) => ({
-                          ...prev,
-                          [applicant.userNo]: payload.otherNotes,
-                        }))
-                      }
+                      setApplicantOtherNotes((prev) => ({
+                        ...prev,
+                        [applicant.userNo]: payload.otherNotes ?? '',
+                      }))
                     } catch (err) {
                       console.error('[rooms] applicant checklist fetch error', applicant.userNo, err)
                     }
@@ -1858,43 +2006,45 @@ const MyRoomPage = () => {
                   </div>
                 </div>
                 <div className="flex flex-col items-end gap-2">
-                  <div className="flex gap-2">
-                    <button 
-                      onClick={() => setApplicantToAccept({ id: applicant.id, name: applicant.name, requestNo: applicant.requestNo })}
-                      className="px-3 py-1 text-xs font-semibold text-blue-600 bg-[#DBEAFE] rounded hover:bg-[#BFDBFE] transition-colors"
-                    >
-                      수락
-                    </button>
-                    <button
-                      onClick={async () => {
-                        if (!room?.roomNo) return
-                        setDirectChatLoadingId(applicant.userNo)
-                        try {
-                          const res = await getOrCreateDirectChatRoom(String(room.roomNo), applicant.userNo)
-                          const chatRoomNo = res.data
-                          if (chatRoomNo) {
-                            navigate(`/chats/${chatRoomNo}`)
-                          } else {
-                            toast.error('채팅방을 찾을 수 없습니다.')
+                  {isHost && (
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => setApplicantToAccept({ id: applicant.id, name: applicant.name, requestNo: applicant.requestNo })}
+                        className="px-3 py-1 text-xs font-semibold text-blue-600 bg-[#DBEAFE] rounded hover:bg-[#BFDBFE] transition-colors"
+                      >
+                        수락
+                      </button>
+                      <button
+                        onClick={async () => {
+                          if (!room?.roomNo) return
+                          setDirectChatLoadingId(applicant.userNo)
+                          try {
+                            const res = await getOrCreateDirectChatRoom(String(room.roomNo), applicant.userNo)
+                            const chatRoomNo = res.data
+                            if (chatRoomNo) {
+                              navigate(`/chats/${chatRoomNo}`)
+                            } else {
+                              toast.error('채팅방을 찾을 수 없습니다.')
+                            }
+                          } catch {
+                            toast.error('채팅방 조회에 실패했습니다.')
+                          } finally {
+                            setDirectChatLoadingId(null)
                           }
-                        } catch {
-                          toast.error('채팅방 조회에 실패했습니다.')
-                        } finally {
-                          setDirectChatLoadingId(null)
-                        }
-                      }}
-                      disabled={directChatLoadingId === applicant.userNo}
-                      className="px-3 py-1 text-xs font-semibold text-gray-700 bg-gray-100 border border-gray-200 rounded hover:bg-gray-200 transition-colors disabled:opacity-50"
-                    >
-                      {directChatLoadingId === applicant.userNo ? '...' : '채팅'}
-                    </button>
-                    <button 
-                      onClick={() => setApplicantToReject({ id: applicant.id, name: applicant.name, requestNo: applicant.requestNo })}
-                      className="px-3 py-1 text-xs font-semibold text-red-600 bg-[#FEDCDC] rounded hover:bg-[#FED0D0] transition-colors"
-                    >
-                      거절
-                    </button>
-                  </div>
+                        }}
+                        disabled={directChatLoadingId === applicant.userNo}
+                        className="px-3 py-1 text-xs font-semibold text-gray-700 bg-gray-100 border border-gray-200 rounded hover:bg-gray-200 transition-colors disabled:opacity-50"
+                      >
+                        {directChatLoadingId === applicant.userNo ? '...' : '채팅'}
+                      </button>
+                      <button
+                        onClick={() => setApplicantToReject({ id: applicant.id, name: applicant.name, requestNo: applicant.requestNo })}
+                        className="px-3 py-1 text-xs font-semibold text-red-600 bg-[#FEDCDC] rounded hover:bg-[#FED0D0] transition-colors"
+                      >
+                        거절
+                      </button>
+                    </div>
+                  )}
                   <button
                     onClick={toggleApplicantChecklist}
                     className="px-3 py-1 text-xs font-semibold text-gray-700 bg-gray-100 border border-gray-200 rounded hover:bg-gray-200 transition-colors whitespace-nowrap"
@@ -1987,39 +2137,25 @@ const MyRoomPage = () => {
             </h3>
             {isHost ? (
               <div className="flex gap-2">
-              <button 
-                onClick={() => setShowRoommateSettings(!showRoommateSettings)}
-                className={`p-2 rounded-lg transition-colors ${
-                    showRoommateSettings ? 'bg-blue-100 text-blue-600' : 'hover:bg-gray-100 text-gray-600'
-                }`}
-              >
-                <Settings className="w-5 h-5" />
-              </button>
-                {myConfirmStatus === 'PENDING' && (
-                  <button 
-                    onClick={() => {
-                      if (roommates.length === 1) {
-                        // 방장이고 혼자만 있을 때만 나가기 가능
-                        setShowLeaveConfirm(true)
-                      } else {
-                        // 방장이지만 다른 사람이 있을 때는 알림
-                        setShowHostLeaveAlert(true)
-                      }
-                    }}
-                    className="p-2 hover:bg-gray-100 text-gray-600 rounded-lg transition-colors"
+                {room?.roomStatus !== 'COMPLETED' && (
+                  <button
+                    onClick={() => setShowRoommateSettings(!showRoommateSettings)}
+                    className={`p-2 rounded-lg transition-colors ${
+                      showRoommateSettings ? 'bg-blue-100 text-blue-600' : 'hover:bg-gray-100 text-gray-600'
+                    }`}
                   >
-                    <DoorOpen className="w-5 h-5" />
+                    <Settings className="w-5 h-5" />
                   </button>
                 )}
               </div>
             ) : (
               myConfirmStatus === 'PENDING' && (
-              <button 
-                onClick={() => setShowLeaveConfirm(true)}
-                className="p-2 hover:bg-gray-100 text-gray-600 rounded-lg transition-colors"
-              >
-                <DoorOpen className="w-5 h-5" />
-              </button>
+                <button
+                  onClick={() => setShowLeaveConfirm(true)}
+                  className="p-2 hover:bg-gray-100 text-gray-600 rounded-lg transition-colors"
+                >
+                  <DoorOpen className="w-5 h-5" />
+                </button>
               )
             )}
           </div>
@@ -2190,7 +2326,7 @@ const MyRoomPage = () => {
                     )}
                   </div>
                 </div>
-                {showRoommateSettings && mate.confirmStatus === 'PENDING' && !mate.isMe ? (
+                {showRoommateSettings && room?.roomStatus !== 'COMPLETED' && !mate.isMe ? (
                   <button 
                     onClick={() => {
                       setRoommateToRemove({ roommateNo: mate.roommateNo, name: displayName })
@@ -2376,13 +2512,7 @@ const MyRoomPage = () => {
                 취소
               </button>
               <button
-                onClick={() => {
-                  // TODO: 내보내기 API 호출
-                  // toast.success(`${roommateToRemove.name}님을 내보냈습니다.`)
-                  setRoommates(prev => prev.filter(r => r.roommateNo !== roommateToRemove.roommateNo))
-                  setRoommateToRemove(null)
-                  setShowRoommateSettings(false)
-                }}
+                onClick={() => void handleKickRoommate()}
                 className="flex-1 px-4 py-3 text-sm font-semibold text-white bg-red-500 rounded-xl hover:bg-red-600 transition-colors"
               >
                 내보내기
@@ -2409,12 +2539,7 @@ const MyRoomPage = () => {
                 취소
               </button>
               <button
-                onClick={() => {
-                  // TODO: 방 나가기 API 호출
-                  // toast.success('방에서 나갔습니다.')
-                  setShowLeaveConfirm(false)
-                  navigate('/rooms/search')
-                }}
+                onClick={() => void handleLeaveRoom()}
                 className="flex-1 px-4 py-3 text-sm font-bold text-red-600 bg-[#FEDCDC] rounded-xl hover:bg-[#FED0D0] transition-colors"
               >
                 나가기
@@ -2440,6 +2565,33 @@ const MyRoomPage = () => {
                 className="flex-1 px-4 py-3 text-sm font-bold text-gray-700 bg-gray-100 rounded-xl hover:bg-gray-200 transition-colors"
               >
                 확인
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showDeleteRoomConfirm && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-2xl p-6 max-w-sm mx-4 shadow-xl">
+            <h3 className="text-lg font-bold text-gray-900 mb-2">방 삭제</h3>
+            <p className="text-sm text-gray-600 mb-6">
+              정말로 방을 삭제하시겠습니까?<br />
+              조건을 만족하지 않으면 삭제되지 않습니다.<br />
+              삭제가 완료되면 방과 채팅 정보가 함께 정리됩니다.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowDeleteRoomConfirm(false)}
+                className="flex-1 px-4 py-3 text-sm font-bold text-gray-700 bg-gray-100 rounded-xl hover:bg-gray-200 transition-colors"
+              >
+                취소
+              </button>
+              <button
+                onClick={() => void handleDeleteRoom()}
+                className="flex-1 px-4 py-3 text-sm font-bold text-white bg-red-500 rounded-xl hover:bg-red-600 transition-colors"
+              >
+                삭제
               </button>
             </div>
           </div>
@@ -2561,11 +2713,23 @@ const MyRoomPage = () => {
       {showConfirmAssignment && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
           <div className="bg-white rounded-2xl p-6 max-w-sm mx-4 shadow-xl">
-            <h3 className="text-lg font-bold text-gray-900 mb-2">방 배정 확정</h3>
+            <h3 className="text-lg font-bold text-gray-900 mb-2">
+              {isHost ? '방 최종 확정' : '방 배정 확정'}
+            </h3>
             <p className="text-sm text-gray-600 mb-6">
-              방 배정을 확정하시겠습니까?<br />
-              확정 후에는 방에서 나갈 수 없으며<br />
-              되돌릴 수 없습니다.
+              {isHost ? (
+                <>
+                  다른 룸메이트가 모두 확정된 상태입니다.<br />
+                  방장이 최종 확정하면 방 전체가 확정되며<br />
+                  이후에는 강퇴할 수 없습니다.
+                </>
+              ) : (
+                <>
+                  방 배정을 확정하시겠습니까?<br />
+                  확정 후에는 되돌릴 수 없으며<br />
+                  방장이 마지막으로 최종 확정하면 방 전체가 확정됩니다.
+                </>
+              )}
             </p>
             <div className="flex gap-3">
               <button

--- a/src/pages/RoomSearchPage.tsx
+++ b/src/pages/RoomSearchPage.tsx
@@ -10,7 +10,6 @@ import ChatRequestModal from '@/components/modals/ChatRequestModal'
 import ConfirmModal from '@/components/ui/ConfirmModal'
 import { Room } from '@/types/room'
 import { getApiUrl } from '@/utils/api'
-import { pruneDeletedRoomState } from './roomSearchDeleteState.js'
 
 const RoomSearchPage = () => {
   const navigate = useNavigate()
@@ -895,26 +894,14 @@ const RoomSearchPage = () => {
   useEffect(() => {
     if (!deletedRoomNo) return
 
-    const nextState = pruneDeletedRoomState(
-      {
-        recruitingRooms,
-        appliedRooms,
-        joinedRooms,
-        expandedRoomIds,
-        roomRules,
-        roomOtherNotes,
-        likedRoomIds,
-      },
-      deletedRoomNo
-    )
-
-    setRecruitingRooms(nextState.recruitingRooms)
-    setAppliedRooms(nextState.appliedRooms)
-    setJoinedRooms(nextState.joinedRooms)
-    setExpandedRoomIds(nextState.expandedRoomIds)
-    setRoomRules(nextState.roomRules)
-    setRoomOtherNotes(nextState.roomOtherNotes)
-    setLikedRoomIds(nextState.likedRoomIds)
+    const id = deletedRoomNo
+    setRecruitingRooms(prev => prev.filter(r => r.id !== id))
+    setAppliedRooms(prev => prev.filter(r => r.id !== id))
+    setJoinedRooms(prev => prev.filter(r => r.id !== id))
+    setExpandedRoomIds(prev => { const next = new Set(prev); next.delete(id); return next })
+    setRoomRules(prev => { const { [id]: _, ...rest } = prev; return rest })
+    setRoomOtherNotes(prev => { const { [id]: _, ...rest } = prev; return rest })
+    setLikedRoomIds(prev => { const next = new Set(prev); next.delete(id); return next })
   }, [deletedRoomNo])
 
   const mapRoomTypeToApi = (type: string) => {

--- a/src/pages/RoomSearchPage.tsx
+++ b/src/pages/RoomSearchPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { Bell, Search, Plus, Filter, Star } from 'lucide-react'
 import BottomNavigationBar from '@/components/ui/BottomNavigationBar'
 import SectionLoading from '@/components/ui/SectionLoading'
@@ -10,9 +10,11 @@ import ChatRequestModal from '@/components/modals/ChatRequestModal'
 import ConfirmModal from '@/components/ui/ConfirmModal'
 import { Room } from '@/types/room'
 import { getApiUrl } from '@/utils/api'
+import { pruneDeletedRoomState } from './roomSearchDeleteState.js'
 
 const RoomSearchPage = () => {
   const navigate = useNavigate()
+  const location = useLocation()
   type Relation = 'recruiting' | 'applied' | 'joined'
   type ApiRoom = {
     roomNo: number
@@ -48,6 +50,7 @@ const RoomSearchPage = () => {
   const [roomRules, setRoomRules] = useState<Record<string, ChecklistSection[]>>({})
   const [roomOtherNotes, setRoomOtherNotes] = useState<Record<string, string>>({})
   const [hasMyRoom, setHasMyRoom] = useState<boolean | null>(null)
+  const isGuest = hasMyRoom === null
   
   // Enum을 한글로 변환하는 함수들 (재사용)
   const mapReturnHomeFromEnum = (enumValue: string): string => {
@@ -591,6 +594,20 @@ const RoomSearchPage = () => {
   const [loadingTab, setLoadingTab] = useState<Relation | null>(null)
   const loadingDelayTimerRef = useRef<number | null>(null)
 
+  const deletedRoomNo =
+    typeof location.state === 'object' &&
+    location.state !== null &&
+    'deletedRoomNo' in location.state &&
+    typeof (location.state as { deletedRoomNo?: unknown }).deletedRoomNo === 'string'
+      ? (location.state as { deletedRoomNo: string }).deletedRoomNo
+      : null
+
+  const refreshRoomsOnEnter =
+    typeof location.state === 'object' &&
+    location.state !== null &&
+    'refreshRooms' in location.state &&
+    Boolean((location.state as { refreshRooms?: unknown }).refreshRooms)
+
   const resetFilters = () => {
     setFilters({ roomType: [], roomSize: [], residencePeriod: [], sort: 'recent', checklist: {} })
   }
@@ -834,42 +851,71 @@ const RoomSearchPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filters.checklist, activeTab, recruitingRooms, appliedRooms, joinedRooms])
 
+  const checkRoomExist = useCallback(async () => {
+    try {
+      const res = await fetch(getApiUrl('/api/rooms/me/exists'), {
+        credentials: 'include',
+      })
+
+      if (res.status === 401) {
+        setHasMyRoom(null)
+        return
+      }
+      if (!res.ok) {
+        setHasMyRoom(false)
+        return
+      }
+
+      const contentType = res.headers.get('content-type') ?? ''
+      const rawBody = await res.text()
+
+      let data: any
+      try {
+        data = rawBody ? JSON.parse(rawBody) : null
+      } catch (e) {
+        console.error('[rooms] check exists parse error', { contentType, rawBody }, e)
+        setHasMyRoom(false)
+        return
+      }
+
+      // ResponseEntity 형식: 직접 접근
+      const payload = data
+      setHasMyRoom(!!payload?.isExist)
+    } catch (err) {
+      console.error('[rooms] check exists error', err)
+      setHasMyRoom(false)
+    }
+  }, [])
+
   // 내가 속한 방 존재 여부 조회
   useEffect(() => {
-    const checkRoomExist = async () => {
-      try {
-        const res = await fetch(getApiUrl('/api/rooms/me/exists'), {
-          credentials: 'include',
-        })
+    void checkRoomExist()
+  }, [checkRoomExist])
 
-        if (!res.ok) {
-          setHasMyRoom(false)
-          return
-        }
+  useEffect(() => {
+    if (!deletedRoomNo) return
 
-        const contentType = res.headers.get('content-type') ?? ''
-        const rawBody = await res.text()
+    const nextState = pruneDeletedRoomState(
+      {
+        recruitingRooms,
+        appliedRooms,
+        joinedRooms,
+        expandedRoomIds,
+        roomRules,
+        roomOtherNotes,
+        likedRoomIds,
+      },
+      deletedRoomNo
+    )
 
-        let data: any
-        try {
-          data = rawBody ? JSON.parse(rawBody) : null
-        } catch (e) {
-          console.error('[rooms] check exists parse error', { contentType, rawBody }, e)
-          setHasMyRoom(false)
-          return
-        }
-
-        // ResponseEntity 형식: 직접 접근
-        const payload = data
-        setHasMyRoom(!!payload?.isExist)
-      } catch (err) {
-        console.error('[rooms] check exists error', err)
-        setHasMyRoom(false)
-      }
-    }
-
-    checkRoomExist()
-  }, [])
+    setRecruitingRooms(nextState.recruitingRooms)
+    setAppliedRooms(nextState.appliedRooms)
+    setJoinedRooms(nextState.joinedRooms)
+    setExpandedRoomIds(nextState.expandedRoomIds)
+    setRoomRules(nextState.roomRules)
+    setRoomOtherNotes(nextState.roomOtherNotes)
+    setLikedRoomIds(nextState.likedRoomIds)
+  }, [deletedRoomNo])
 
   const mapRoomTypeToApi = (type: string) => {
     switch (type) {
@@ -1196,6 +1242,7 @@ const RoomSearchPage = () => {
     const handleVisibility = () => {
       if (document.visibilityState === 'visible' && activeTab === 'recruiting') {
         const refreshKey = `recruiting-refresh-${Date.now()}`
+        void checkRoomExist()
         void fetchRooms('recruiting', { showLoading: false, requestKey: refreshKey })
       }
     }
@@ -1205,7 +1252,16 @@ const RoomSearchPage = () => {
       window.removeEventListener('focus', handleVisibility)
       document.removeEventListener('visibilitychange', handleVisibility)
     }
-  }, [activeTab, fetchRooms])
+  }, [activeTab, checkRoomExist, fetchRooms])
+
+  useEffect(() => {
+    if (!refreshRoomsOnEnter) return
+
+    void checkRoomExist()
+    void fetchRooms('recruiting', { showLoading: false, requestKey: `location-refresh-recruiting-${Date.now()}` })
+    void fetchRooms('joined', { showLoading: false, requestKey: `location-refresh-joined-${Date.now()}` })
+    void fetchRooms('applied', { showLoading: false, requestKey: `location-refresh-applied-${Date.now()}` })
+  }, [checkRoomExist, fetchRooms, refreshRoomsOnEnter])
 
   return (
     <div className="page-with-bottom-nav h-screen bg-white flex flex-col overflow-hidden animate-fade-in">
@@ -1405,9 +1461,8 @@ const RoomSearchPage = () => {
             </div>
           </div>
 
-          {/* 방 만들기 버튼 - 로그인한 사용자만 표시 */}
-        {/* 로그인 여부는 서버의 인증 쿠키 기준으로 판단 */}
-        {true && (
+          {/* 방 만들기 버튼 - 로그인했고 아직 속한 방이 없는 사용자에게만 표시 */}
+        {!isGuest && hasMyRoom === false && (
             <button
               onClick={handleCreateRoom}
               className="w-full bg-[#3072E1] text-white px-4 py-2.5 rounded-xl text-sm font-medium flex items-center justify-center space-x-2 hover:bg-[#2563E1] mb"
@@ -1433,8 +1488,8 @@ const RoomSearchPage = () => {
               >
                 모집 중인 방
               </button>
-              {/* 로그인한 사용자만 다른 탭 표시 - 인증은 서버에서 처리 */}
-              {true && (
+              {/* 로그인한 사용자만 관심/지원 탭 표시 */}
+              {!isGuest && (
                 <>
                   <button
                     onClick={() => setActiveTab('joined')}
@@ -1590,12 +1645,10 @@ const RoomSearchPage = () => {
                                 
                                 if (payload) {
                                   // 기타 메모 저장
-                                  if (payload.otherNotes) {
-                                    setRoomOtherNotes((prev) => ({
-                                      ...prev,
-                                      [room.id]: payload.otherNotes || '',
-                                    }))
-                                  }
+                                  setRoomOtherNotes((prev) => ({
+                                    ...prev,
+                                    [room.id]: payload.otherNotes ?? '',
+                                  }))
 
                                   // API 응답을 체크리스트 섹션 형식으로 변환
                                   const checklistSections = convertApiRuleToChecklistSections(payload)
@@ -1936,12 +1989,10 @@ const RoomSearchPage = () => {
                                 
                                 if (payload) {
                                   // 기타 메모 저장
-                                  if (payload.otherNotes) {
-                                    setRoomOtherNotes((prev) => ({
-                                      ...prev,
-                                      [room.id]: payload.otherNotes || '',
-                                    }))
-                                  }
+                                  setRoomOtherNotes((prev) => ({
+                                    ...prev,
+                                    [room.id]: payload.otherNotes ?? '',
+                                  }))
 
                                   // API 응답을 체크리스트 섹션 형식으로 변환
                                   const checklistSections = convertApiRuleToChecklistSections(payload)

--- a/src/pages/myRoomRuleUtils.test.ts
+++ b/src/pages/myRoomRuleUtils.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  buildRoomRuleFetchPath,
+  normalizeRoomRuleTimeValue,
+  selectSingleOption,
+} from './myRoomRuleUtils'
+
+describe('selectSingleOption', () => {
+  test('새 옵션을 선택하면 이전 선택은 해제한다', () => {
+    const options = [
+      { text: '진동', selected: true },
+      { text: '소리', selected: false },
+    ]
+
+    expect(selectSingleOption(options, 1)).toEqual([
+      { text: '진동', selected: false },
+      { text: '소리', selected: true },
+    ])
+  })
+
+  test('이미 선택된 옵션을 다시 누르면 선택 해제한다', () => {
+    const options = [
+      { text: '항상', selected: true },
+      { text: '유동적', selected: false },
+    ]
+
+    expect(selectSingleOption(options, 0)).toEqual([
+      { text: '항상', selected: false },
+      { text: '유동적', selected: false },
+    ])
+  })
+})
+
+describe('buildRoomRuleFetchPath', () => {
+  test('방 규칙 재조회는 roomNo path param 경로를 사용한다', () => {
+    expect(buildRoomRuleFetchPath('123')).toBe('/api/rooms/123/rule')
+  })
+})
+
+describe('normalizeRoomRuleTimeValue', () => {
+  test('빈 시간값은 BE 검증을 통과하도록 기본값으로 보정한다', () => {
+    expect(normalizeRoomRuleTimeValue('')).toBe('00:00')
+    expect(normalizeRoomRuleTimeValue('   ')).toBe('00:00')
+  })
+
+  test('실제 선택된 시간값은 유지한다', () => {
+    expect(normalizeRoomRuleTimeValue('23시')).toBe('23시')
+  })
+})

--- a/src/pages/myRoomRuleUtils.ts
+++ b/src/pages/myRoomRuleUtils.ts
@@ -1,0 +1,28 @@
+export type ChecklistOption = {
+  text: string
+  selected?: boolean
+}
+
+export const selectSingleOption = (
+  options: ChecklistOption[],
+  optionIndex: number
+): ChecklistOption[] => {
+  const isCurrentlySelected = options[optionIndex]?.selected ?? false
+
+  if (isCurrentlySelected) {
+    return options.map((option) => ({
+      ...option,
+      selected: false,
+    }))
+  }
+
+  return options.map((option, index) => ({
+    ...option,
+    selected: index === optionIndex,
+  }))
+}
+
+export const buildRoomRuleFetchPath = (roomNo: string) => `/api/rooms/${roomNo}/rule`
+
+export const normalizeRoomRuleTimeValue = (value: string) =>
+  value && value.trim() !== '' ? value : '00:00'

--- a/src/pages/roomSearchDeleteState.d.ts
+++ b/src/pages/roomSearchDeleteState.d.ts
@@ -1,0 +1,16 @@
+import type { Room } from '@/types/room'
+
+type RoomSearchDeleteState = {
+  recruitingRooms: Room[]
+  appliedRooms: Room[]
+  joinedRooms: Room[]
+  expandedRoomIds: Set<string>
+  roomRules: Record<string, any>
+  roomOtherNotes: Record<string, string>
+  likedRoomIds: Set<string>
+}
+
+export function pruneDeletedRoomState(
+  state: RoomSearchDeleteState,
+  deletedRoomNo: string | null
+): RoomSearchDeleteState

--- a/src/pages/roomSearchDeleteState.js
+++ b/src/pages/roomSearchDeleteState.js
@@ -1,0 +1,35 @@
+export const pruneDeletedRoomState = (state, deletedRoomNo) => {
+  if (!deletedRoomNo) {
+    return {
+      recruitingRooms: state.recruitingRooms,
+      appliedRooms: state.appliedRooms,
+      joinedRooms: state.joinedRooms,
+      expandedRoomIds: state.expandedRoomIds,
+      roomRules: state.roomRules,
+      roomOtherNotes: state.roomOtherNotes,
+      likedRoomIds: state.likedRoomIds,
+    }
+  }
+
+  const nextExpandedRoomIds = new Set(state.expandedRoomIds)
+  nextExpandedRoomIds.delete(deletedRoomNo)
+
+  const nextRoomRules = { ...state.roomRules }
+  delete nextRoomRules[deletedRoomNo]
+
+  const nextRoomOtherNotes = { ...state.roomOtherNotes }
+  delete nextRoomOtherNotes[deletedRoomNo]
+
+  const nextLikedRoomIds = new Set(state.likedRoomIds)
+  nextLikedRoomIds.delete(deletedRoomNo)
+
+  return {
+    recruitingRooms: state.recruitingRooms.filter((room) => room.id !== deletedRoomNo),
+    appliedRooms: state.appliedRooms.filter((room) => room.id !== deletedRoomNo),
+    joinedRooms: state.joinedRooms.filter((room) => room.id !== deletedRoomNo),
+    expandedRoomIds: nextExpandedRoomIds,
+    roomRules: nextRoomRules,
+    roomOtherNotes: nextRoomOtherNotes,
+    likedRoomIds: nextLikedRoomIds,
+  }
+}

--- a/src/services/chatApi.ts
+++ b/src/services/chatApi.ts
@@ -23,3 +23,9 @@ export const getChatRoomMembers = (chatRoomNo: string) =>
   apiClient.get<{ userNo: string; nickname: string; isHost: boolean }[]>(
     `/api/chat/rooms/${chatRoomNo}/members`
   )
+
+export const findMyGroupChatRoomByRoomNo = async (roomNo: string) => {
+  const res = await getChatRooms()
+  const rooms = Array.isArray(res.data) ? res.data : []
+  return rooms.find((room) => room.chatRoomType === 'GROUP' && room.roomNo === roomNo) ?? null
+}

--- a/src/services/roomApi.ts
+++ b/src/services/roomApi.ts
@@ -1,0 +1,7 @@
+import apiClient from './apiClient'
+
+export const kickRoommate = (roomNo: string, kickedUserNo: string) =>
+  apiClient.delete(`/api/rooms/${roomNo}/members/${kickedUserNo}`)
+
+export const deleteRoom = (roomNo: string) =>
+  apiClient.delete(`/api/rooms/${roomNo}`)

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -14,6 +14,8 @@ interface ChatStore {
   setMessages: (chatRoomNo: string, msgs: ChatMessage[], nextCursor: string | null, hasNext: boolean) => void
   prependMessages: (chatRoomNo: string, msgs: ChatMessage[], nextCursor: string | null, hasNext: boolean) => void
   appendMessage: (chatRoomNo: string, message: ChatMessage) => void
+  removeChatRoom: (chatRoomNo: string) => void
+  removeGroupChatRoomsByRoomNo: (roomNo: string) => void
 }
 
 export const useChatStore = create<ChatStore>((set) => ({
@@ -67,4 +69,38 @@ export const useChatStore = create<ChatStore>((set) => ({
         [chatRoomNo]: [...(state.messages[chatRoomNo] ?? []), message],
       },
     })),
+  removeChatRoom: (chatRoomNo) =>
+    set((state) => ({
+      chatRooms: state.chatRooms.filter((room) => room.chatRoomNo !== chatRoomNo),
+      messages: Object.fromEntries(
+        Object.entries(state.messages).filter(([key]) => key !== chatRoomNo)
+      ),
+      cursors: Object.fromEntries(
+        Object.entries(state.cursors).filter(([key]) => key !== chatRoomNo)
+      ),
+      hasMore: Object.fromEntries(
+        Object.entries(state.hasMore).filter(([key]) => key !== chatRoomNo)
+      ),
+    })),
+  removeGroupChatRoomsByRoomNo: (roomNo) =>
+    set((state) => {
+      const targetChatRoomNos = state.chatRooms
+        .filter((room) => room.chatRoomType === 'GROUP' && room.roomNo === roomNo)
+        .map((room) => room.chatRoomNo)
+
+      return {
+        chatRooms: state.chatRooms.filter(
+          (room) => !(room.chatRoomType === 'GROUP' && room.roomNo === roomNo)
+        ),
+        messages: Object.fromEntries(
+          Object.entries(state.messages).filter(([key]) => !targetChatRoomNos.includes(key))
+        ),
+        cursors: Object.fromEntries(
+          Object.entries(state.cursors).filter(([key]) => !targetChatRoomNos.includes(key))
+        ),
+        hasMore: Object.fromEntries(
+          Object.entries(state.hasMore).filter(([key]) => !targetChatRoomNos.includes(key))
+        ),
+      }
+    }),
 }))

--- a/src/types/bun-test.d.ts
+++ b/src/types/bun-test.d.ts
@@ -1,0 +1,8 @@
+declare module 'bun:test' {
+  export const describe: (name: string, fn: () => void) => void
+  export const test: (name: string, fn: () => void | Promise<void>) => void
+  export const expect: <T>(actual: T) => {
+    toBe(expected: T): void
+    toEqual(expected: unknown): void
+  }
+}


### PR DESCRIPTION
## 요약
  방 관리 흐름과 채팅/검색 화면의 방 상태 동기화를 개선했습니다.
  특히 방 관리에서 규칙 편집 후 저장해도 이전 값으로 보이던 문제를 수정했고,
  방 삭제/방 나가기/룸메이트 내보내기 이후 관련 화면 상태가 자연스럽게 반영되도록 정리했습니다.

  ## 변경 사항
  ### 1. 방 관리(MyRoomPage) 개선
  - 방 규칙 편집 저장 시 선택값이 올바르게 반영되도록 수정
  - 추가 규칙 선택 로직을 단일 선택 기준으로 정리
  - 귀가/소등 시간값이 비어 있을 때 저장이 실패하지 않도록 보정
  - 방 규칙 재조회 경로를 일관되게 정리
  - 방장 기준으로 지원자 탭 노출 여부 제어
  - 방장용 방 삭제 기능 추가
  - 룸메이트 내보내기 기능 연결
  - 방 나가기 기능 연결
  - 방장 최종 확정 가능 조건을 UI에서 제어
  - 규칙 수정 실패 시 사용자에게 에러 토스트가 보이도록 개선

  ### 2. 채팅방(ChatRoomPage) 상태 동기화
  - 그룹 채팅 멤버 목록에 룸메이트 메타 정보(confirmStatus, isMe) 반영
  - 방장이 채팅 패널에서 룸메이트를 내보낼 수 있도록 UI/동작 추가
  - 강퇴/방 삭제 알림 수신 시 채팅방 목록과 메시지 상태를 store에서 제거
  - 채팅방 나가기 시 store 상태도 함께 정리
  - STOMP 구독 내부에서 stale closure를 피하도록 ref 동기화 처리

  ### 3. 방 검색(RoomSearchPage) 상태 동기화
  - 방 삭제/방 나가기 이후 location state를 받아 목록 상태를 정리하도록 수정
  - 모집/지원/관심 목록 재조회 흐름 보강
  - 로그인/비로그인 상태에 따라 방 만들기 버튼과 탭 노출 조건 정리
  - otherNotes가 빈 값일 때도 일관되게 처리

  ### 4. 공통 유틸 및 API 추가
  - room rule 편집 관련 유틸 추가
    - `buildRoomRuleFetchPath`
    - `selectSingleOption`
    - `normalizeRoomRuleTimeValue`
  - 룸메이트 내보내기/방 삭제용 `roomApi` 추가
  - 삭제된 방 상태 정리용 `roomSearchDeleteState` 유틸 추가
  - 채팅 store에 채팅방/그룹채팅 정리 메서드 추가

  ## 기대 효과
  - 방 관리에서 수정한 규칙이 저장 후 다시 이전 값으로 보이는 문제를 줄입니다.
  - 방 삭제/강퇴/방 나가기 이후 채팅방 목록과 방 검색 화면 상태가 어긋나지 않도록 맞춥니다.
  - 방장 기준 액션(지원자 관리, 최종 확정, 강퇴, 삭제)의 UI 조건이 더 명확해집니다.

  ## 참고
  - 방 규칙 수정이 실제 DB에 반영되려면 백엔드의 `room rule update no-op` 수정이 함께 반영되어야 합니다.
  - FE PR과 BE PR을 함께 배포하는 것이 안전합니다.