### PR TITLE
[FIX] 채팅 서버 연동 — mock 제거 및 REST/WebSocket 실시간 연결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,19 @@
       "name": "dorumdorum",
       "version": "0.1.0",
       "dependencies": {
+        "@stomp/stompjs": "^7.3.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.27.0"
+        "react-router-dom": "^6.27.0",
+        "sockjs-client": "^1.6.1"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.15",
-        "vite": "^5.4.11"
+        "vite": "^5.4.11",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -34,13 +37,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -49,9 +52,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -59,21 +62,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -90,14 +93,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -107,14 +110,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -124,9 +127,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -134,29 +137,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -166,9 +169,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -176,9 +179,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -186,9 +189,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -196,9 +199,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -206,27 +209,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -236,13 +239,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
-      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -252,13 +255,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
-      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -268,33 +271,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -302,14 +305,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -795,9 +798,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -811,9 +814,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
-      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
       "cpu": [
         "arm"
       ],
@@ -825,9 +828,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
-      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
       "cpu": [
         "arm64"
       ],
@@ -839,9 +842,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
-      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
       "cpu": [
         "arm64"
       ],
@@ -853,9 +856,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
-      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
       "cpu": [
         "x64"
       ],
@@ -867,9 +870,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
-      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
       "cpu": [
         "arm64"
       ],
@@ -881,9 +884,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
-      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
       "cpu": [
         "x64"
       ],
@@ -895,9 +898,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
-      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
       "cpu": [
         "arm"
       ],
@@ -909,9 +912,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
-      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
       "cpu": [
         "arm"
       ],
@@ -923,9 +926,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
-      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
       "cpu": [
         "arm64"
       ],
@@ -937,9 +940,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
-      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
       "cpu": [
         "arm64"
       ],
@@ -951,9 +954,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
-      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
       "cpu": [
         "loong64"
       ],
@@ -965,9 +968,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
-      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
       "cpu": [
         "loong64"
       ],
@@ -979,9 +982,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
-      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
       "cpu": [
         "ppc64"
       ],
@@ -993,9 +996,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
-      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
       "cpu": [
         "ppc64"
       ],
@@ -1007,9 +1010,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
-      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
       "cpu": [
         "riscv64"
       ],
@@ -1021,9 +1024,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
-      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
       "cpu": [
         "riscv64"
       ],
@@ -1035,9 +1038,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
-      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
       "cpu": [
         "s390x"
       ],
@@ -1049,9 +1052,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
       "cpu": [
         "x64"
       ],
@@ -1063,9 +1066,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
-      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
       "cpu": [
         "x64"
       ],
@@ -1077,9 +1080,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
-      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
       "cpu": [
         "x64"
       ],
@@ -1091,9 +1094,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
-      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
       "cpu": [
         "arm64"
       ],
@@ -1105,9 +1108,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
-      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
       "cpu": [
         "arm64"
       ],
@@ -1119,9 +1122,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
-      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
       "cpu": [
         "ia32"
       ],
@@ -1133,9 +1136,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
       "cpu": [
         "x64"
       ],
@@ -1147,9 +1150,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
-      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
       "cpu": [
         "x64"
       ],
@@ -1159,6 +1162,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.3.0.tgz",
+      "integrity": "sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1206,9 +1215,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1231,6 +1240,119 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/any-promise": {
@@ -1260,6 +1382,16 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
@@ -1299,9 +1431,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.32",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
-      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1371,6 +1503,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -1382,9 +1524,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -1401,6 +1543,33 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -1488,6 +1657,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -1503,9 +1682,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.361",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
-      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
+      "version": "1.5.372",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
+      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1518,6 +1697,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1568,6 +1754,35 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -1606,6 +1821,18 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/fill-range": {
@@ -1684,9 +1911,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1695,6 +1922,18 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -1832,6 +2071,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1840,6 +2086,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/merge2": {
@@ -1870,7 +2126,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -1905,9 +2160,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
-      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1950,6 +2205,23 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2134,9 +2406,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2152,6 +2424,12 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
@@ -2211,12 +2489,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2226,13 +2504,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2264,6 +2542,12 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -2299,13 +2583,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
-      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2315,31 +2599,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.4",
-        "@rollup/rollup-android-arm64": "4.60.4",
-        "@rollup/rollup-darwin-arm64": "4.60.4",
-        "@rollup/rollup-darwin-x64": "4.60.4",
-        "@rollup/rollup-freebsd-arm64": "4.60.4",
-        "@rollup/rollup-freebsd-x64": "4.60.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
-        "@rollup/rollup-linux-arm64-musl": "4.60.4",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
-        "@rollup/rollup-linux-loong64-musl": "4.60.4",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
-        "@rollup/rollup-linux-x64-gnu": "4.60.4",
-        "@rollup/rollup-linux-x64-musl": "4.60.4",
-        "@rollup/rollup-openbsd-x64": "4.60.4",
-        "@rollup/rollup-openharmony-arm64": "4.60.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
-        "@rollup/rollup-win32-x64-gnu": "4.60.4",
-        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -2367,6 +2651,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -2386,6 +2690,41 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sockjs-client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
+        "inherits": "^2.0.4",
+        "url-parse": "^1.5.10"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
+      }
+    },
+    "node_modules/sockjs-client/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2395,6 +2734,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -2493,10 +2846,24 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2539,6 +2906,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -2590,6 +2987,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -2657,6 +3064,135 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -6,18 +6,23 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
+    "@stomp/stompjs": "^7.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.27.0"
+    "react-router-dom": "^6.27.0",
+    "sockjs-client": "^1.6.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.15",
-    "vite": "^5.4.11"
+    "vite": "^5.4.11",
+    "vitest": "^2.1.9"
   }
 }

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { AppRoutes } from './routes.jsx';
+import { ChatNotificationGate } from '../features/chat/ChatNotificationGate.jsx';
 
 export default function App() {
-  return <AppRoutes />;
+  return (
+    <ChatNotificationGate>
+      <AppRoutes />
+    </ChatNotificationGate>
+  );
 }
 

--- a/src/app/routes.jsx
+++ b/src/app/routes.jsx
@@ -47,8 +47,8 @@ export function AppRoutes() {
         <Route path="/dorm-rules/general" element={<DormRulesScreen />} />
         <Route path="/rooms/:id" element={<RoomDetailScreen />} />
         <Route path="/rooms/:id/apply" element={<ApplyMessageScreen />} />
-        <Route path="/chat/group" element={<ChatDetailScreen />} />
-        <Route path="/chat/dm" element={<ChatDMScreen />} />
+        <Route path="/chat/group/:chatRoomNo" element={<ChatDetailScreen />} />
+        <Route path="/chat/dm/:chatRoomNo" element={<ChatDMScreen />} />
 
         {/* Flow screens */}
         <Route path="/checklist" element={<ChecklistEditScreen mode="personal" />} />

--- a/src/features/chat/ChatNotificationGate.jsx
+++ b/src/features/chat/ChatNotificationGate.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { subscribe } from '../../shared/api/chatSocket';
+import { getCachedUserNo } from '../../shared/api/auth';
+
+// 로그인 상태에서 개인 알림 큐를 구독. 방 삭제/강퇴 시 사용자에게 알리고 채팅 목록으로 보낸다.
+export function ChatNotificationGate({ children }) {
+  const navigate = useNavigate();
+
+  React.useEffect(() => {
+    if (!getCachedUserNo()) return;
+    let alive = true;
+    let unsub = () => {};
+
+    subscribe('/user/queue/notification', (msg) => {
+      if (!alive) return;
+      if (msg.type === 'ROOM_DELETED') {
+        alert('방이 삭제되어 채팅방이 닫혔어요.');
+        navigate('/chat');
+      } else if (msg.type === 'KICKED_FROM_ROOM') {
+        alert('방에서 내보내져 채팅방이 닫혔어요.');
+        navigate('/chat');
+      }
+    }).then((fn) => { if (alive) unsub = fn; else fn(); });
+
+    return () => { alive = false; unsub(); };
+  }, [navigate]);
+
+  return children;
+}

--- a/src/features/chat/index.js
+++ b/src/features/chat/index.js
@@ -2,8 +2,8 @@ export {
   ChatListScreen,
   ChatDetailScreen,
   ChatBubble,
+  ChatMessageItem,
   ChatComposer,
-  ChatAttachmentCard,
   formatChatTime,
 } from './pages/Chat.jsx';
 

--- a/src/features/chat/pages/Chat.jsx
+++ b/src/features/chat/pages/Chat.jsx
@@ -1,16 +1,10 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { Icon, TabBar, StatusBar, Avatar, MarqueeText, ClipText, goBack } from '../../../shared/components';
-
-// chat.jsx — ChatList + ChatDetail (KakaoTalk bubble style)
-
-const CHATS = [
-  { id: 1, name: '아침형 룸메 구해요 🌅 2생활관 4인실', last: '수민: 내일 7시에 같이 모닝커피 어때요?', time: '오후 05:42', unread: 3, group: true, tone: '' },
-  { id: 2, name: '지원', last: '안녕하세요! 입주 신청 드렸습니다 :)', time: '오후 04:18', unread: 1, tone: 'sky' },
-  { id: 3, name: '서연', last: '체크리스트 확인하고 답장드릴게요', time: '오후 02:30', unread: 0, tone: 'plum' },
-  { id: 4, name: '학생생활관 사감팀', last: '5월 입사식 안내드립니다.', time: '오전 11:02', unread: 0, official: true, tone: 'sage' },
-  { id: 5, name: '지호', last: '네 좋습니다 그럼 그렇게 진행해요', time: '어제', unread: 0, tone: 'sand' },
-];
+import { loadMyChatRooms, loadChatMessages, markChatRoomRead, leaveChatRoom, getChatRoomMembers } from '../../../shared/api/chat';
+import { subscribe, publish } from '../../../shared/api/chatSocket';
+import { applyReadReceipt, appendMessage } from '../unreadSync';
+import { getCachedUserNo } from '../../../shared/api/auth';
 
 export function formatChatTime(date = new Date()) {
   const hour = date.getHours();
@@ -20,29 +14,44 @@ export function formatChatTime(date = new Date()) {
   return `${period} ${displayHour}:${minute}`;
 }
 
-function formatFileSize(size = 0) {
-  if (size >= 1024 * 1024) return `${(size / 1024 / 1024).toFixed(1)}MB`;
-  if (size >= 1024) return `${Math.round(size / 1024)}KB`;
-  return `${size}B`;
-}
-
 export function ChatListScreen({ activeTab='chat' }) {
   const navigate = useNavigate();
   const [filter, setFilter] = React.useState('전체');
-  const visibleChats = CHATS.filter((chat) => {
-    if (filter === '내 방') return chat.group;
-    if (filter === '읽지 않음') return chat.unread > 0;
+  const [rooms, setRooms] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState('');
+
+  React.useEffect(() => {
+    let alive = true;
+    loadMyChatRooms()
+      .then((data) => { if (alive) setRooms(Array.isArray(data) ? data : []); })
+      .catch(() => { if (alive) setError('채팅방을 불러오지 못했어요.'); })
+      .finally(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, []);
+
+  const visibleRooms = rooms.filter((room) => {
+    if (filter === '내 방') return room.chatRoomType === 'GROUP';
+    if (filter === '읽지 않음') return room.unreadCount > 0;
     return true;
   });
 
-	  return (
-	    <div className="screen">
-	      <div className="scroll">
-	        <StatusBar />
-		        <div className="topbar">
-		          <div className="brand">채팅</div>
-		        </div>
-	        <div style={{ padding: '0 16px 8px', display: 'flex', gap: 6, overflowX: 'auto' }}>
+  const titleOf = (room) =>
+    room.chatRoomType === 'GROUP' ? (room.roomName || '채팅방') : (room.partnerNickname || '상대방');
+
+  const openRoom = (room) => {
+    const path = room.chatRoomType === 'GROUP' ? '/chat/group/' : '/chat/dm/';
+    navigate(path + room.chatRoomNo);
+  };
+
+  return (
+    <div className="screen">
+      <div className="scroll">
+        <StatusBar />
+        <div className="topbar">
+          <div className="brand">채팅</div>
+        </div>
+        <div style={{ padding: '0 16px 8px', display: 'flex', gap: 6, overflowX: 'auto' }}>
           {['전체', '내 방', '읽지 않음'].map((f) => (
             <button
               key={f}
@@ -56,49 +65,58 @@ export function ChatListScreen({ activeTab='chat' }) {
           ))}
         </div>
 
-        <div style={{ background: 'var(--surface)', margin: '4px 16px 0', borderRadius: 18, overflow: 'hidden' }}>
-          {visibleChats.map((c, i, arr) => (
-            <div key={c.id} onClick={() => navigate(c.group ? '/chat/group' : '/chat/dm')} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '14px 14px', borderBottom: i === arr.length - 1 ? 'none' : '1px solid var(--line)', cursor: 'pointer' }}>
-              <div style={{ position: 'relative' }}>
-                {c.group ? (
-                  <div style={{ width: 48, height: 48, borderRadius: 14, background: 'var(--brand)', color: 'white', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                    <Icon.door size={24} weight={2} />
-                  </div>
-                ) : (
-                  <Avatar name={c.name.slice(0,1)} tone={c.tone} size={48} style={{ fontSize: 20 }}/>
-                )}
-                {c.official && <span style={{ position: 'absolute', bottom: -2, right: -2, width: 18, height: 18, borderRadius: '50%', background: 'var(--brand)', color: 'white', display: 'flex', alignItems: 'center', justifyContent: 'center', border: '2px solid var(--surface)' }}><Icon.check size={10} weight={3}/></span>}
-              </div>
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                  <span style={{ fontSize: 15, fontWeight: 700, minWidth: 0, flex: '0 1 auto', display: 'block', overflow: 'hidden' }}>
-                    <MarqueeText>{c.name}</MarqueeText>
-                  </span>
-                  {c.group && <span style={{ fontSize: 12, color: 'var(--ink-3)', flexShrink: 0 }}>4</span>}
-                </div>
-                <div style={{ fontSize: 13, color: 'var(--ink-3)', marginTop: 4 }}>
-                  <ClipText>{c.last}</ClipText>
-                </div>
-              </div>
-              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 6 }}>
-                <span style={{ fontSize: 11, color: 'var(--ink-3)' }}>{c.time}</span>
-                {c.unread > 0 && (
-                  <span style={{ minWidth: 18, height: 18, padding: '0 5px', borderRadius: 9, background: 'var(--brand)', color: 'white', fontSize: 11, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>{c.unread}</span>
-                )}
-              </div>
-            </div>
-          ))}
-        </div>
+        {loading && <div style={{ padding: '24px 16px', color: 'var(--ink-3)', fontSize: 13 }}>불러오는 중…</div>}
+        {error && <div style={{ padding: '24px 16px', color: 'var(--danger)', fontSize: 13 }}>{error}</div>}
+        {!loading && !error && visibleRooms.length === 0 && (
+          <div style={{ padding: '24px 16px', color: 'var(--ink-3)', fontSize: 13 }}>채팅방이 없어요.</div>
+        )}
 
-        <div style={{ height: 24 }}/>
+        {!loading && !error && visibleRooms.length > 0 && (
+          <div style={{ background: 'var(--surface)', margin: '4px 16px 0', borderRadius: 18, overflow: 'hidden' }}>
+            {visibleRooms.map((room, i, arr) => {
+              const isGroup = room.chatRoomType === 'GROUP';
+              const title = titleOf(room);
+              return (
+                <div key={room.chatRoomNo} onClick={() => openRoom(room)} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '14px 14px', borderBottom: i === arr.length - 1 ? 'none' : '1px solid var(--line)', cursor: 'pointer' }}>
+                  <div style={{ position: 'relative' }}>
+                    {isGroup ? (
+                      <div style={{ width: 48, height: 48, borderRadius: 14, background: 'var(--brand)', color: 'white', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                        <Icon.door size={24} weight={2} />
+                      </div>
+                    ) : (
+                      <Avatar name={title.slice(0, 1)} size={48} style={{ fontSize: 20 }} />
+                    )}
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                      <span style={{ fontSize: 15, fontWeight: 700, minWidth: 0, flex: '0 1 auto', display: 'block', overflow: 'hidden' }}>
+                        <MarqueeText>{title}</MarqueeText>
+                      </span>
+                    </div>
+                    <div style={{ fontSize: 13, color: 'var(--ink-3)', marginTop: 4 }}>
+                      <ClipText>{room.lastMessageContent || '아직 메시지가 없어요'}</ClipText>
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 6 }}>
+                    <span style={{ fontSize: 11, color: 'var(--ink-3)' }}>{room.lastMessageAt ? formatChatTime(new Date(room.lastMessageAt)) : ''}</span>
+                    {room.unreadCount > 0 && (
+                      <span style={{ minWidth: 18, height: 18, padding: '0 5px', borderRadius: 9, background: 'var(--brand)', color: 'white', fontSize: 11, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>{room.unreadCount}</span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        <div style={{ height: 24 }} />
       </div>
 
-      <TabBar active={activeTab}/>
+      <TabBar active={activeTab} />
     </div>
   );
 }
 
-// ── Chat detail (KakaoTalk-style bubbles) ───────────────────
 export function ChatBubble({ side='left', name, time, tone='', children, withTail=true, showAvatar=true, showName=true, unread=0 }) {
   const isMe = side === 'right';
   return (
@@ -131,118 +149,42 @@ export function ChatBubble({ side='left', name, time, tone='', children, withTai
   );
 }
 
-export function ChatAttachmentCard({ attachment, mine=false }) {
-  if (!attachment) return null;
-  const isImage = attachment.kind === 'image';
-  return (
-    <div style={{ minWidth: 180, maxWidth: 220 }}>
-      {isImage && attachment.previewUrl && (
-        <img
-          src={attachment.previewUrl}
-          alt={attachment.name}
-          style={{ width: '100%', maxHeight: 150, objectFit: 'cover', borderRadius: 12, display: 'block', marginBottom: 8 }}
-        />
-      )}
-      <div style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 10,
-        padding: isImage ? 0 : 10,
-        borderRadius: 12,
-        background: isImage ? 'transparent' : mine ? 'rgba(255,255,255,0.16)' : 'var(--surface-2)',
-        color: mine ? 'white' : 'var(--ink)',
-      }}>
-        {!isImage && (
-          <div style={{ width: 34, height: 34, borderRadius: 10, background: mine ? 'rgba(255,255,255,0.18)' : 'var(--brand-soft)', color: mine ? 'white' : 'var(--brand-deep)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-            <Icon.file size={18} />
-          </div>
-        )}
-        <div style={{ minWidth: 0, flex: 1 }}>
-          <div style={{ fontSize: 13, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{attachment.name}</div>
-          <div style={{ fontSize: 11, opacity: 0.72, marginTop: 2 }}>{isImage ? '사진' : '파일'} · {formatFileSize(attachment.size)}</div>
-        </div>
+// SYSTEM이면 가운데 회색 텍스트, TEXT이면 ChatBubble.
+export function ChatMessageItem({ message, myUserNo }) {
+  if (message.messageType === 'SYSTEM') {
+    return (
+      <div style={{ textAlign: 'center', margin: '12px 0' }}>
+        <span style={{ fontSize: 11, color: 'var(--ink-3)' }}>{message.content}</span>
       </div>
-    </div>
+    );
+  }
+  const mine = message.senderNo === myUserNo;
+  return (
+    <ChatBubble
+      side={mine ? 'right' : 'left'}
+      name={message.senderNickname}
+      time={formatChatTime(new Date(message.sentAt))}
+      unread={message.unreadCount}
+    >
+      {message.content}
+    </ChatBubble>
   );
 }
 
-export function ChatComposer({ onSend }) {
+// 텍스트 전용. 첨부파일은 서버 미지원으로 제거됨.
+export function ChatComposer({ onSend, disabled = false }) {
   const [text, setText] = React.useState('');
-  const [menuOpen, setMenuOpen] = React.useState(false);
-  const [attachment, setAttachment] = React.useState(null);
-  const imageInputRef = React.useRef(null);
-  const fileInputRef = React.useRef(null);
-  const canSend = text.trim() || attachment;
-
-  const selectAttachment = (kind) => (event) => {
-    const file = event.target.files?.[0];
-    event.target.value = '';
-    if (!file) return;
-
-    const next = {
-      id: `${Date.now()}-${file.name}`,
-      kind,
-      name: file.name,
-      size: file.size,
-    };
-
-    if (kind === 'image') {
-      const reader = new FileReader();
-      reader.onload = () => setAttachment({ ...next, previewUrl: reader.result });
-      reader.readAsDataURL(file);
-    } else {
-      setAttachment(next);
-    }
-
-    setMenuOpen(false);
-  };
+  const canSend = !disabled && text.trim();
 
   const send = () => {
     if (!canSend) return;
-    onSend?.({
-      id: Date.now(),
-      text: text.trim(),
-      attachment,
-      time: formatChatTime(),
-    });
+    onSend?.(text.trim());
     setText('');
-    setAttachment(null);
-    setMenuOpen(false);
   };
 
   return (
     <div style={{ padding: '8px 12px 14px', background: 'var(--surface)', borderTop: '1px solid var(--line)' }}>
-      <input ref={imageInputRef} type="file" accept="image/*" onChange={selectAttachment('image')} style={{ display: 'none' }} />
-      <input ref={fileInputRef} type="file" onChange={selectAttachment('file')} style={{ display: 'none' }} />
-
-      {menuOpen && (
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginBottom: 8 }}>
-          <button type="button" onClick={() => imageInputRef.current?.click()} style={{ minHeight: 54, border: 0, borderRadius: 14, background: 'var(--surface-2)', color: 'var(--ink)', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, fontFamily: 'inherit', fontSize: 14, fontWeight: 700, cursor: 'pointer' }}>
-            <Icon.image size={19} /> 사진
-          </button>
-          <button type="button" onClick={() => fileInputRef.current?.click()} style={{ minHeight: 54, border: 0, borderRadius: 14, background: 'var(--surface-2)', color: 'var(--ink)', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, fontFamily: 'inherit', fontSize: 14, fontWeight: 700, cursor: 'pointer' }}>
-            <Icon.file size={19} /> 파일
-          </button>
-        </div>
-      )}
-
-      {attachment && (
-        <div style={{ marginBottom: 8, borderRadius: 14, background: 'var(--surface-2)', padding: 10, display: 'flex', alignItems: 'center', gap: 10 }}>
-          <div style={{ width: 36, height: 36, borderRadius: 10, background: attachment.kind === 'image' ? 'var(--brand-soft)' : 'var(--surface)', color: attachment.kind === 'image' ? 'var(--brand-deep)' : 'var(--ink-2)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-            {attachment.kind === 'image' ? <Icon.image size={18} /> : <Icon.file size={18} />}
-          </div>
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--ink)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{attachment.name}</div>
-            <div style={{ fontSize: 11, color: 'var(--ink-3)', marginTop: 2 }}>{attachment.kind === 'image' ? '사진' : '파일'} · {formatFileSize(attachment.size)}</div>
-          </div>
-          <button type="button" onClick={() => setAttachment(null)} aria-label="첨부 취소" style={{ width: 30, height: 30, borderRadius: '50%', border: 0, background: 'var(--surface)', color: 'var(--ink-3)', fontSize: 18, lineHeight: 1, cursor: 'pointer' }}>×</button>
-        </div>
-      )}
-
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <button type="button" onClick={() => setMenuOpen((v) => !v)} aria-label="첨부 메뉴" style={{ width: 36, height: 36, borderRadius: '50%', border: 0, background: menuOpen ? 'var(--brand-soft)' : 'var(--surface-2)', color: menuOpen ? 'var(--brand-deep)' : 'var(--ink-2)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
-          <Icon.plus size={20} />
-        </button>
         <input
           value={text}
           onChange={(e) => setText(e.target.value)}
@@ -253,6 +195,7 @@ export function ChatComposer({ onSend }) {
             }
           }}
           placeholder="메시지 보내기"
+          disabled={disabled}
           style={{ flex: 1, minWidth: 0, height: 38, border: 0, outline: 'none', background: 'var(--surface-2)', borderRadius: 18, padding: '0 14px', fontSize: 14, color: 'var(--ink)', fontFamily: 'inherit' }}
         />
         <button type="button" onClick={send} disabled={!canSend} style={{ width: 36, height: 36, borderRadius: '50%', border: 0, background: 'var(--brand)', color: 'white', display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: canSend ? 1 : 0.45, cursor: canSend ? 'pointer' : 'not-allowed' }}>
@@ -265,13 +208,72 @@ export function ChatComposer({ onSend }) {
 
 export function ChatDetailScreen() {
   const navigate = useNavigate();
+  const { chatRoomNo } = useParams();
+  const myUserNo = React.useMemo(() => getCachedUserNo(), []);
   const [menuOpen, setMenuOpen] = React.useState(false);
-  const [sentMessages, setSentMessages] = React.useState([]);
-  const isHost = true;
-  const currentMembers = 4;
-  const canLeaveRoom = !isHost || currentMembers <= 1;
-  const sendChatMessage = (message) => {
-    setSentMessages((items) => [...items, { ...message, unread: Math.max(0, currentMembers - 1) }]);
+  const [messages, setMessages] = React.useState([]);
+  const [members, setMembers] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const scrollRef = React.useRef(null);
+
+  const isHost = members.find((m) => m.userNo === myUserNo)?.isHost ?? false;
+  const canLeaveRoom = !isHost || members.length <= 1;
+
+  React.useEffect(() => {
+    if (!chatRoomNo) return;
+    let alive = true;
+    setLoading(true);
+    Promise.all([
+      getChatRoomMembers(chatRoomNo).catch(() => []),
+      loadChatMessages(chatRoomNo).catch(() => ({ items: [] })),
+    ]).then(([memberList, page]) => {
+      if (!alive) return;
+      setMembers(Array.isArray(memberList) ? memberList : []);
+      const items = (page?.items || []).slice().reverse();
+      setMessages(items);
+      setLoading(false);
+      markChatRoomRead(chatRoomNo).catch(() => {});
+    });
+    return () => { alive = false; };
+  }, [chatRoomNo]);
+
+  React.useEffect(() => {
+    if (!chatRoomNo) return;
+    let unsubMsg = () => {};
+    let unsubRead = () => {};
+    let alive = true;
+
+    subscribe(`/topic/chat-room/${chatRoomNo}`, (incoming) => {
+      if (!alive) return;
+      setMessages((prev) => appendMessage(prev, incoming));
+      if (incoming.senderNo !== myUserNo) {
+        markChatRoomRead(chatRoomNo).catch(() => {});
+      }
+    }).then((fn) => { if (alive) unsubMsg = fn; else fn(); });
+
+    subscribe(`/topic/chat-room/${chatRoomNo}/read`, (receipt) => {
+      if (!alive) return;
+      if (receipt.readerUserNo === myUserNo) return;
+      setMessages((prev) => applyReadReceipt(prev, receipt));
+    }).then((fn) => { if (alive) unsubRead = fn; else fn(); });
+
+    return () => { alive = false; unsubMsg(); unsubRead(); };
+  }, [chatRoomNo, myUserNo]);
+
+  React.useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages]);
+
+  const sendChatMessage = (text) => {
+    publish(`/app/chat-room/${chatRoomNo}/send`, { content: text }).catch(() => {});
+  };
+
+  const handleLeave = () => {
+    if (!canLeaveRoom) return;
+    leaveChatRoom(chatRoomNo)
+      .then(() => { setMenuOpen(false); navigate('/chat'); })
+      .catch((e) => { alert(e?.message || '나갈 수 없어요.'); });
   };
 
   return (
@@ -286,75 +288,40 @@ export function ChatDetailScreen() {
           <div style={{ flex: 1, minWidth: 0 }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
               <span style={{ fontSize: 15, fontWeight: 700, minWidth: 0, flex: '0 1 auto', display: 'block', overflow: 'hidden' }}>
-                <MarqueeText>아침형 룸메 구해요 · 2생활관 4인실</MarqueeText>
+                <MarqueeText>채팅방</MarqueeText>
               </span>
-              <span style={{ fontSize: 13, color: 'var(--ink-3)', flexShrink: 0 }}>4</span>
+              <span style={{ fontSize: 13, color: 'var(--ink-3)', flexShrink: 0 }}>{members.length || ''}</span>
             </div>
-            <div style={{ fontSize: 11, color: 'var(--ink-3)', marginTop: 2 }}>2생활관 · 4인실</div>
           </div>
-	          <button onClick={() => setMenuOpen(true)} aria-label="채팅방 메뉴" style={{ background: 'transparent', border: 0, padding: 6, color: 'var(--ink)', cursor: 'pointer' }}>
+          <button onClick={() => setMenuOpen(true)} aria-label="채팅방 메뉴" style={{ background: 'transparent', border: 0, padding: 6, color: 'var(--ink)', cursor: 'pointer' }}>
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/></svg>
           </button>
         </div>
       </div>
 
-      {/* Pinned notice */}
-      <div onClick={() => navigate('/notice/1')} style={{ margin: '8px 12px 0', background: 'var(--brand-soft)', border: '1px solid var(--brand-soft)', borderRadius: 12, padding: '8px 12px', display: 'flex', alignItems: 'center', gap: 8, fontSize: 12, color: 'var(--brand-deep)', cursor: 'pointer' }}>
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none"><path d="M12 2l2 6h6l-5 4 2 7-7-4-7 4 2-7L0 8h6l6-6z" fill="currentColor"/></svg>
-        <span style={{ flex: 1, fontWeight: 600 }}>일요일 저녁 7시 — 5월 청소 당번 정하기</span>
-        <Icon.chevron size={12}/>
-      </div>
-
-      <div className="scroll" style={{ padding: '14px 12px 8px' }}>
-        {/* Date divider */}
-        <div style={{ textAlign: 'center', margin: '4px 0 14px' }}>
-          <span style={{ fontSize: 11, color: 'var(--ink-3)', background: 'rgba(0,0,0,0.05)', padding: '4px 12px', borderRadius: 99 }}>2026년 5월 21일 목요일</span>
-        </div>
-
-        <ChatBubble side="left" name="강민지" tone="" time="오후 05:30">안녕하세요~ 새로 입주하실 분들 반가워요 :)</ChatBubble>
-        <ChatBubble side="left" name="강민지" tone="" time="오후 05:31" showAvatar={false} showName={false}>저는 보통 7시쯤 일어나서 같이 모닝커피 하실 분 환영이에요 ☕️</ChatBubble>
-
-        <div style={{ height: 8 }}/>
-        <ChatBubble side="right" time="오후 05:35" unread={2}>와 저도 아침형이에요!</ChatBubble>
-        <ChatBubble side="right" time="오후 05:35" withTail={false} unread={1}>매칭 추천에 떠서 신청드렸어요 ㅎㅎ</ChatBubble>
-
-        <div style={{ height: 8 }}/>
-        <ChatBubble side="left" name="수민" tone="sage" time="오후 05:40">저도요!! 청소 당번은 어떻게 정해요?</ChatBubble>
-
-        <div style={{ height: 8 }}/>
-        <ChatBubble side="left" name="수민" tone="sage" time="오후 05:42" showAvatar={false} showName={false}>
-          내일 7시에 같이 모닝커피 어때요? <br/>저 카페 마실래요 ☺️
-        </ChatBubble>
-
-        <div style={{ textAlign: 'center', margin: '12px 0' }}>
-          <span style={{ fontSize: 11, color: 'var(--ink-3)' }}>지호님이 입장했어요</span>
-        </div>
-
-        <ChatBubble side="left" name="지호" tone="sand" time="오후 05:43">반가워요! 잘 부탁드려요 🙌</ChatBubble>
-        {sentMessages.map((message) => (
-          <ChatBubble key={message.id} side="right" time={message.time} unread={message.unread}>
-            {message.attachment && <ChatAttachmentCard attachment={message.attachment} mine />}
-            {message.text && <div style={{ marginTop: message.attachment ? 8 : 0 }}>{message.text}</div>}
-          </ChatBubble>
+      <div className="scroll" ref={scrollRef} style={{ padding: '14px 12px 8px' }}>
+        {loading && <div style={{ textAlign: 'center', color: 'var(--ink-3)', fontSize: 13, padding: 24 }}>불러오는 중…</div>}
+        {!loading && messages.length === 0 && (
+          <div style={{ textAlign: 'center', color: 'var(--ink-3)', fontSize: 13, padding: 24 }}>첫 메시지를 보내보세요.</div>
+        )}
+        {messages.map((m) => (
+          <ChatMessageItem key={m.messageNo} message={m} myUserNo={myUserNo} />
         ))}
       </div>
 
-      {/* Composer */}
-      <ChatComposer onSend={sendChatMessage} />
+      <ChatComposer onSend={sendChatMessage} disabled={loading} />
+
       {menuOpen && (
         <div onClick={() => setMenuOpen(false)} style={{ position: 'absolute', inset: 0, zIndex: 20, background: 'rgba(23,24,28,0.28)', display: 'flex', alignItems: 'flex-end' }}>
           <div onClick={(e) => e.stopPropagation()} style={{ width: '100%', background: 'var(--surface)', borderRadius: '22px 22px 0 0', padding: '10px 16px 30px', boxShadow: '0 -16px 40px rgba(23,24,28,0.14)' }}>
             <div style={{ width: 38, height: 4, borderRadius: 99, background: 'var(--line-2)', margin: '0 auto 14px' }} />
             <div style={{ padding: '0 2px 14px' }}>
               <div style={{ fontSize: 18, fontWeight: 700, letterSpacing: '-0.3px' }}>채팅방 메뉴</div>
-              <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 4 }}>아침형 룸메 구해요 · 현재 {currentMembers}명</div>
+              <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 4 }}>현재 {members.length}명</div>
             </div>
             <button
               type="button"
-              onClick={() => {
-                setMenuOpen(false);
-                navigate('/rooms/members');
-              }}
+              onClick={() => { setMenuOpen(false); navigate('/rooms/members'); }}
               style={{ width: '100%', minHeight: 52, border: 0, borderRadius: 14, background: 'var(--surface-2)', color: 'var(--ink)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 14px', fontFamily: 'inherit', fontSize: 15, fontWeight: 700, cursor: 'pointer', marginBottom: 8 }}
             >
               <span>방 멤버 보기</span>
@@ -362,11 +329,7 @@ export function ChatDetailScreen() {
             </button>
             <button
               type="button"
-              onClick={() => {
-                if (!canLeaveRoom) return;
-                setMenuOpen(false);
-                navigate('/chat');
-              }}
+              onClick={handleLeave}
               disabled={!canLeaveRoom}
               style={{ width: '100%', minHeight: 52, border: 0, borderRadius: 14, background: canLeaveRoom ? 'rgba(226,69,60,0.08)' : 'var(--surface-2)', color: canLeaveRoom ? 'var(--danger)' : 'var(--ink-4)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 14px', fontFamily: 'inherit', fontSize: 15, fontWeight: 700, cursor: canLeaveRoom ? 'pointer' : 'not-allowed' }}
             >

--- a/src/features/chat/pages/Chat.jsx
+++ b/src/features/chat/pages/Chat.jsx
@@ -222,7 +222,7 @@ export function ChatComposer({ onSend, disabled = false }) {
           value={text}
           onChange={(e) => setText(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === 'Enter') {
+            if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
               e.preventDefault();
               send();
             }
@@ -265,7 +265,6 @@ export function ChatDetailScreen() {
       const items = (page?.items || []).slice().reverse();
       setMessages(items);
       setLoading(false);
-      markChatRoomRead(chatRoomNo).catch(() => {});
     });
     return () => { alive = false; };
   }, [chatRoomNo]);
@@ -276,19 +275,26 @@ export function ChatDetailScreen() {
     let unsubRead = () => {};
     let alive = true;
 
-    subscribe(`/topic/chat-room/${chatRoomNo}`, (incoming) => {
+    const pMsg = subscribe(`/topic/chat-room/${chatRoomNo}`, (incoming) => {
       if (!alive) return;
       setMessages((prev) => appendMessage(prev, incoming));
       if (incoming.senderNo !== myUserNo) {
         markChatRoomRead(chatRoomNo).catch(() => {});
       }
-    }).then((fn) => { if (alive) unsubMsg = fn; else fn(); });
+    });
 
-    subscribe(`/topic/chat-room/${chatRoomNo}/read`, (receipt) => {
+    const pRead = subscribe(`/topic/chat-room/${chatRoomNo}/read`, (receipt) => {
       if (!alive) return;
-      if (receipt.readerUserNo === myUserNo) return;
       setMessages((prev) => applyReadReceipt(prev, receipt));
-    }).then((fn) => { if (alive) unsubRead = fn; else fn(); });
+    });
+
+    // 두 구독이 모두 준비된 뒤 읽음 처리 — 이 시점에 서버 broadcast를 수신할 수 있음
+    Promise.all([pMsg, pRead]).then(([fnMsg, fnRead]) => {
+      if (!alive) { fnMsg(); fnRead(); return; }
+      unsubMsg = fnMsg;
+      unsubRead = fnRead;
+      markChatRoomRead(chatRoomNo).catch(() => {});
+    });
 
     return () => { alive = false; unsubMsg(); unsubRead(); };
   }, [chatRoomNo, myUserNo]);

--- a/src/features/chat/pages/Chat.jsx
+++ b/src/features/chat/pages/Chat.jsx
@@ -68,7 +68,40 @@ export function ChatListScreen({ activeTab='chat' }) {
         {loading && <div style={{ padding: '24px 16px', color: 'var(--ink-3)', fontSize: 13 }}>불러오는 중…</div>}
         {error && <div style={{ padding: '24px 16px', color: 'var(--danger)', fontSize: 13 }}>{error}</div>}
         {!loading && !error && visibleRooms.length === 0 && (
-          <div style={{ padding: '24px 16px', color: 'var(--ink-3)', fontSize: 13 }}>채팅방이 없어요.</div>
+          <div style={{ padding: '42px 24px 24px', display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center' }}>
+            <div style={{ width: 72, height: 72, borderRadius: 22, background: 'var(--surface-2)', color: 'var(--ink-4)', display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 18, position: 'relative' }}>
+              <Icon.chat size={32} weight={1.9} />
+            </div>
+            <div style={{ fontSize: 16, fontWeight: 800, color: 'var(--ink)', letterSpacing: '-0.2px' }}>
+              룸메이트 모집을 통해 채팅방을 만들어보세요.
+            </div>
+            <div style={{ fontSize: 13, color: 'var(--ink-3)', lineHeight: 1.5, marginTop: 7 }}>
+              모집방을 만들거나 입주 신청을 하면 대화를 시작할 수 있어요.
+            </div>
+            <button
+              type="button"
+              onClick={() => navigate('/rooms/create/1')}
+              style={{
+                marginTop: 20,
+                height: 48,
+                padding: '0 17px',
+                borderRadius: 24,
+                border: 0,
+                background: 'var(--ink)',
+                color: 'white',
+                fontFamily: 'inherit',
+                fontSize: 14,
+                fontWeight: 800,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+                cursor: 'pointer',
+                boxShadow: '0 8px 24px rgba(0,0,0,0.14)',
+              }}
+            >
+              <Icon.plus size={18} /> 모집방 만들기
+            </button>
+          </div>
         )}
 
         {!loading && !error && visibleRooms.length > 0 && (

--- a/src/features/chat/unreadSync.js
+++ b/src/features/chat/unreadSync.js
@@ -1,0 +1,19 @@
+export function applyReadReceipt(messages, receipt) {
+  const readAt = new Date(receipt.readAt).getTime();
+  return messages.map((m) => {
+    if (m.senderNo === receipt.readerUserNo) return m;
+    if (m.unreadCount <= 0) return m;
+    if (new Date(m.sentAt).getTime() > readAt) return m;
+    return { ...m, unreadCount: m.unreadCount - 1 };
+  });
+}
+
+export function appendMessage(messages, incoming) {
+  const idx = messages.findIndex((m) => m.messageNo === incoming.messageNo);
+  if (idx >= 0) {
+    const next = messages.slice();
+    next[idx] = incoming;
+    return next;
+  }
+  return [...messages, incoming];
+}

--- a/src/features/chat/unreadSync.test.js
+++ b/src/features/chat/unreadSync.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { applyReadReceipt, appendMessage } from './unreadSync';
+
+const msg = (over) => ({
+  messageNo: '1', senderNo: 'A', content: 'hi',
+  messageType: 'TEXT', sentAt: '2026-06-14T10:00:00', unreadCount: 2, ...over,
+});
+
+describe('applyReadReceipt', () => {
+  it('reader가 아닌 사람의 메시지 중 readAt 이전/같음이고 unread>0이면 1 감소', () => {
+    const messages = [msg({ messageNo: '1', senderNo: 'A', sentAt: '2026-06-14T10:00:00', unreadCount: 2 })];
+    const result = applyReadReceipt(messages, { readerUserNo: 'B', readAt: '2026-06-14T10:05:00' });
+    expect(result[0].unreadCount).toBe(1);
+  });
+
+  it('reader 본인이 보낸 메시지는 감소하지 않는다', () => {
+    const messages = [msg({ senderNo: 'B', unreadCount: 2 })];
+    const result = applyReadReceipt(messages, { readerUserNo: 'B', readAt: '2026-06-14T10:05:00' });
+    expect(result[0].unreadCount).toBe(2);
+  });
+
+  it('readAt 이후 전송된 메시지는 감소하지 않는다', () => {
+    const messages = [msg({ sentAt: '2026-06-14T10:10:00', unreadCount: 2 })];
+    const result = applyReadReceipt(messages, { readerUserNo: 'B', readAt: '2026-06-14T10:05:00' });
+    expect(result[0].unreadCount).toBe(2);
+  });
+
+  it('unreadCount가 이미 0이면 음수로 내려가지 않는다', () => {
+    const messages = [msg({ unreadCount: 0 })];
+    const result = applyReadReceipt(messages, { readerUserNo: 'B', readAt: '2026-06-14T10:05:00' });
+    expect(result[0].unreadCount).toBe(0);
+  });
+});
+
+describe('appendMessage', () => {
+  it('새 메시지를 뒤에 추가한다', () => {
+    const result = appendMessage([msg({ messageNo: '1' })], msg({ messageNo: '2' }));
+    expect(result.map((m) => m.messageNo)).toEqual(['1', '2']);
+  });
+
+  it('동일 messageNo는 중복 추가하지 않고 최신 값으로 대체한다', () => {
+    const result = appendMessage([msg({ messageNo: '1', unreadCount: 2 })], msg({ messageNo: '1', unreadCount: 1 }));
+    expect(result).toHaveLength(1);
+    expect(result[0].unreadCount).toBe(1);
+  });
+});

--- a/src/features/checklist/pages/Details.jsx
+++ b/src/features/checklist/pages/Details.jsx
@@ -1,21 +1,34 @@
 import React from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { Icon, StatusBar, Avatar, goBack } from '../../../shared/components';
 import { logout as logoutUser, getCachedUserNo } from '../../../shared/api/auth';
+import { loadMyRoom } from '../../../shared/api/home';
+import { submitRoomApplication, approveApplication, rejectApplication, loadMyRoomRule, updateMyRoomRule, createRoom } from '../../../shared/api/room';
 import { ChatMessageItem, ChatComposer } from '../../chat';
 import { getOrCreateDirectChatRoom, loadChatMessages, markChatRoomRead, leaveChatRoom } from '../../../shared/api/chat';
 import { subscribe, publish } from '../../../shared/api/chatSocket';
 import { applyReadReceipt, appendMessage } from '../../chat/unreadSync';
+import {
+  checklistFormToRoomRuleRequest,
+  createRoomDraftToRequest,
+  defaultRoomChecklistForm,
+  roomRuleToChecklistForm,
+} from '../../rooms/roomData';
 
 // details.jsx — Detail screens for each tab
 
 // ─── Common: simple top nav with back arrow ─────────────────
-export function TopNav({ title, right, backTo }) {
+export function TopNav({ title, right, backTo, collapsible = true }) {
   const navigate = useNavigate();
   const navRef = React.useRef(null);
   const [collapsed, setCollapsed] = React.useState(false);
 
   React.useEffect(() => {
+    if (!collapsible) {
+      setCollapsed(false);
+      return undefined;
+    }
+
     const parent = navRef.current?.parentElement;
     const scroller = parent?.querySelector(':scope > .scroll') || parent?.querySelector('.scroll');
     if (!scroller) return undefined;
@@ -46,7 +59,7 @@ export function TopNav({ title, right, backTo }) {
 
     scroller.addEventListener('scroll', onScroll, { passive: true });
     return () => scroller.removeEventListener('scroll', onScroll);
-  }, []);
+  }, [collapsible]);
 
   return (
     <div ref={navRef} style={{
@@ -293,20 +306,40 @@ export function ChecklistEditScreen({ mode = 'personal' }) {
     sleepHabit: null, snore: null, shower: null, eating: null,
     lightsOut: null, lightsOutHour: 23, visitHome: null, smoke: null, fridge: null,
     alarm: null, earphone: null, skinCare: null, silentMouse: null, hot: null, cold: null, study: null, trash: null,
-  } : {
-    sleep: { start: 23, end: 1 },
-    wake: { start: 7, end: 9 },
-    dryer: null,
-    homing: '유동적', cleaning: '주기적', call: '가능', dim: '어두움',
-    sleepHabit: '약함', snore: '약함~없음', shower: '저녁', eating: '가능+환기필수',
-    lightsOut: '시간 지정', lightsOutHour: 23, visitHome: '2주', smoke: '비흡연', fridge: '협의 후 결정',
-    alarm: '진동', earphone: '항상', skinCare: '유동적', silentMouse: '사용', hot: '중간', cold: '중간', study: '유동적', trash: '개별',
-  });
+  } : defaultRoomChecklistForm);
   const upd = (k, val) => setV({ ...v, [k]: val });
   const [headerCollapsed, setHeaderCollapsed] = React.useState(false);
+  const [roomContext, setRoomContext] = React.useState(null);
+  const [roomRuleLoading, setRoomRuleLoading] = React.useState(isRoomEdit);
+  const [roomRuleSaving, setRoomRuleSaving] = React.useState(false);
   const scrollRef = React.useRef(null);
 
+  React.useEffect(() => {
+    if (!isRoomEdit) return undefined;
+    let mounted = true;
+    setRoomRuleLoading(true);
+    loadMyRoom()
+      .then((room) => {
+        setRoomContext(room);
+        return loadMyRoomRule(room.roomNo);
+      })
+      .then((rule) => { if (mounted) setV(roomRuleToChecklistForm(rule)); })
+      .catch(() => { if (mounted) alert('방 체크리스트를 불러오지 못했어요.'); })
+      .finally(() => { if (mounted) setRoomRuleLoading(false); });
+    return () => { mounted = false; };
+  }, [isRoomEdit]);
+
+  const saveRoomRule = () => {
+    if (!roomContext || roomRuleSaving) return;
+    setRoomRuleSaving(true);
+    updateMyRoomRule(roomContext.roomNo, checklistFormToRoomRuleRequest(v, roomContext))
+      .then(() => navigate('/rooms/checklist'))
+      .catch((e) => alert(e?.message || '방 체크리스트를 저장하지 못했어요.'))
+      .finally(() => setRoomRuleSaving(false));
+  };
+
   const handleScroll = () => {
+    if (isRoomCreate) return;
     if (scrollRef.current) {
       setHeaderCollapsed(scrollRef.current.scrollTop > 10);
     }
@@ -317,7 +350,7 @@ export function ChecklistEditScreen({ mode = 'personal' }) {
       <StatusBar />
       {isRoomCreate ?
       <>
-          <TopNav title="모집방 만들기" backTo="/rooms/create/1" />
+          <TopNav title="모집방 만들기" backTo="/rooms/create/1" collapsible={false} />
           <div style={{ padding: '0 20px 10px' }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, color: 'var(--ink-3)', marginBottom: 6, fontWeight: 600 }}>
               <span>2 / 3 단계</span>
@@ -329,10 +362,10 @@ export function ChecklistEditScreen({ mode = 'personal' }) {
           </div>
           <div style={{
             overflow: 'hidden',
-            maxHeight: headerCollapsed ? 0 : 100,
-            opacity: headerCollapsed ? 0 : 1,
+            maxHeight: 100,
+            opacity: 1,
             transition: 'max-height 0.25s ease, opacity 0.2s ease',
-            padding: headerCollapsed ? '0 20px' : '6px 20px 0',
+            padding: '6px 20px 0',
           }}>
             <div style={{ fontSize: 20, fontWeight: 700, letterSpacing: '-0.4px', lineHeight: 1.35 }}>
               어떤 룸메이트를 찾으시나요?
@@ -346,7 +379,7 @@ export function ChecklistEditScreen({ mode = 'personal' }) {
           <TopNav
           title="방 체크리스트"
           backTo="/rooms/checklist"
-          right={<button onClick={() => navigate('/rooms/checklist')} style={{ background: 'transparent', border: 0, fontSize: 13, color: 'var(--brand)', fontWeight: 700, cursor: 'pointer' }}>저장</button>}
+          right={<button onClick={saveRoomRule} disabled={roomRuleLoading || roomRuleSaving || !roomContext} style={{ background: 'transparent', border: 0, fontSize: 13, color: 'var(--brand)', fontWeight: 700, cursor: roomRuleLoading || roomRuleSaving || !roomContext ? 'not-allowed' : 'pointer', opacity: roomRuleLoading || roomRuleSaving || !roomContext ? 0.45 : 1 }}>{roomRuleSaving ? '저장 중' : '저장'}</button>}
         />
           <div style={{ padding: '6px 20px 0' }}>
             <div style={{ fontSize: 20, fontWeight: 700, letterSpacing: '-0.4px', lineHeight: 1.35 }}>
@@ -366,6 +399,9 @@ export function ChecklistEditScreen({ mode = 'personal' }) {
       }
 
       <div ref={scrollRef} onScroll={handleScroll} className="scroll" style={{ padding: isRoom ? '12px 20px 0' : '0 20px' }}>
+        {isRoomEdit && roomRuleLoading && (
+          <div style={{ padding: 24, textAlign: 'center', color: 'var(--ink-3)', fontSize: 13 }}>방 체크리스트를 불러오는 중...</div>
+        )}
         {/* Section 1 */}
         <div style={{ padding: '10px 0 8px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <h2 style={{ margin: 0, fontSize: 19, fontWeight: 700, letterSpacing: '-0.4px' }}>생활 패턴</h2>
@@ -497,13 +533,13 @@ export function ChecklistEditScreen({ mode = 'personal' }) {
       {isRoomCreate &&
       <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, padding: '14px 16px'  , background: 'transparent', display: 'flex', gap: 8 }}>
           <button onClick={() => navigate('/rooms/create/1')} className="btn ghost" style={{ width: 80, height: 52 }}>이전</button>
-          <button onClick={() => navigate('/rooms/create/3')} className="btn full" style={{ flex: 1, height: 52 }}>다음</button>
+          <button onClick={() => { saveCreateRoomRuleDraft(v); navigate('/rooms/create/3'); }} className="btn full" style={{ flex: 1, height: 52 }}>다음</button>
         </div>
       }
       {isRoomEdit &&
       <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, padding: '14px 16px 30px', background: 'var(--surface)', borderTop: '1px solid var(--line)', display: 'flex', gap: 8 }}>
           <button onClick={() => navigate('/rooms/checklist')} className="btn ghost" style={{ width: 80, height: 52 }}>취소</button>
-          <button onClick={() => navigate('/rooms/checklist')} className="btn full" style={{ flex: 1, height: 52 }}>저장</button>
+          <button onClick={saveRoomRule} disabled={roomRuleLoading || roomRuleSaving || !roomContext} className="btn full" style={{ flex: 1, height: 52, opacity: roomRuleLoading || roomRuleSaving || !roomContext ? 0.45 : 1 }}>{roomRuleSaving ? '저장 중...' : '저장'}</button>
         </div>
       }
       {!isRoom &&
@@ -517,11 +553,17 @@ export function ChecklistEditScreen({ mode = 'personal' }) {
 
 // ─── Create-room Step 3: Preview & publish ──────────────────
 const CREATE_ROOM_DRAFT_KEY = 'dorumdorum:create-room-draft';
+const CREATE_ROOM_RULE_DRAFT_KEY = 'dorumdorum:create-room-rule-draft';
+const PROFILE_STORAGE_KEY = 'dorumdorum:profile';
 const DEFAULT_CREATE_ROOM_DRAFT = {
-  title: '아침형 룸메 구해요',
+  title: '',
   dorm: '2생활관',
   roomSize: '4인실',
   residencePeriod: 'SEMESTER',
+  notes: '',
+};
+const LEGACY_CREATE_ROOM_DRAFT = {
+  title: '아침형 룸메 구해요',
   notes: '아침 7시쯤 일어나는 사람이면 좋아요. 청소는 일주일에 두 번 같이 하면 좋겠어요.',
 };
 
@@ -538,25 +580,88 @@ export const CREATE_ROOM_DORMS = [
 ];
 export const ROOM_SIZE_OPTIONS = ['1인실', '2인실', '3인실', '4인실'];
 
+function withChecklistDefaults(value = {}) {
+  return Object.fromEntries(
+    Object.entries(defaultRoomChecklistForm).map(([key, fallback]) => [
+      key,
+      value[key] == null ? fallback : value[key],
+    ]),
+  );
+}
+
 function readCreateRoomDraft() {
   if (typeof window === 'undefined') return DEFAULT_CREATE_ROOM_DRAFT;
   try {
     const saved = window.sessionStorage.getItem(CREATE_ROOM_DRAFT_KEY);
-    return saved ? { ...DEFAULT_CREATE_ROOM_DRAFT, ...JSON.parse(saved) } : DEFAULT_CREATE_ROOM_DRAFT;
+    if (!saved) return DEFAULT_CREATE_ROOM_DRAFT;
+    const draft = { ...DEFAULT_CREATE_ROOM_DRAFT, ...JSON.parse(saved) };
+    return {
+      ...draft,
+      title: draft.title === LEGACY_CREATE_ROOM_DRAFT.title ? '' : draft.title,
+      notes: draft.notes === LEGACY_CREATE_ROOM_DRAFT.notes ? '' : draft.notes,
+    };
   } catch {
     return DEFAULT_CREATE_ROOM_DRAFT;
+  }
+}
+
+function readCreateRoomRuleDraft() {
+  if (typeof window === 'undefined') return defaultRoomChecklistForm;
+  try {
+    const saved = window.sessionStorage.getItem(CREATE_ROOM_RULE_DRAFT_KEY);
+    return saved ? withChecklistDefaults(JSON.parse(saved)) : defaultRoomChecklistForm;
+  } catch {
+    return defaultRoomChecklistForm;
+  }
+}
+
+function saveCreateRoomRuleDraft(value) {
+  if (typeof window === 'undefined') return;
+  window.sessionStorage.setItem(CREATE_ROOM_RULE_DRAFT_KEY, JSON.stringify(withChecklistDefaults(value)));
+}
+
+function readCachedProfileName() {
+  if (typeof window === 'undefined') return '방장';
+  try {
+    const profile = JSON.parse(window.localStorage.getItem(PROFILE_STORAGE_KEY) || '{}');
+    return profile.displayName || profile.accountName || '방장';
+  } catch {
+    return '방장';
   }
 }
 
 export function CreateRoomStep3Screen() {
   const navigate = useNavigate();
   const draft = readCreateRoomDraft();
+  const ruleDraft = readCreateRoomRuleDraft();
   const capacity = Number.parseInt(draft.roomSize, 10) || 4;
+  const hostName = readCachedProfileName();
+  const previewTitle = draft.title?.trim();
+  const previewNotes = draft.notes?.trim();
+  const canPublish = previewTitle.length > 0;
+  const [submitting, setSubmitting] = React.useState(false);
+  const [submitError, setSubmitError] = React.useState('');
+
+  const publishRoom = () => {
+    if (submitting) return;
+    if (!canPublish) {
+      setSubmitError('모집글 제목을 입력해주세요.');
+      return;
+    }
+    setSubmitting(true);
+    setSubmitError('');
+    createRoom(createRoomDraftToRequest(draft, ruleDraft))
+      .then(() => navigate('/rooms/create/success', { state: { draft } }))
+      .catch((error) => {
+        setSubmitError(error?.message || '모집방을 등록하지 못했어요.');
+        setSubmitting(false);
+      });
+  };
 
   return (
     <div className="screen">
       <StatusBar />
-      <TopNav title="모집방 만들기" backTo="/rooms/create/2" />
+      <TopNav title="모집방 만들기" backTo="/rooms/create/2" collapsible={false} />
 
       <div style={{ padding: '0 20px 10px' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, color: 'var(--ink-3)', marginBottom: 6, fontWeight: 600 }}>
@@ -581,14 +686,14 @@ export function CreateRoomStep3Screen() {
         {/* Preview card */}
         <div className="card" style={{ padding: 16, marginBottom: 12 }}>
           <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--ink-3)', letterSpacing: '0.4px', marginBottom: 8 }}>미리보기</div>
-          <div style={{ fontSize: 18, fontWeight: 700, letterSpacing: '-0.3px' }}>{draft.title || DEFAULT_CREATE_ROOM_DRAFT.title}</div>
+          <div style={{ fontSize: 18, fontWeight: 700, letterSpacing: '-0.3px', color: previewTitle ? 'var(--ink)' : 'var(--ink-3)' }}>{previewTitle || '모집글 제목을 입력해주세요.'}</div>
           <div style={{ fontSize: 13, color: 'var(--ink-3)', marginTop: 4 }}>{draft.dorm} · {draft.roomSize}</div>
           <div style={{ fontSize: 14, color: 'var(--ink-2)', lineHeight: 1.55, marginTop: 12 }}>
-            {draft.notes || '방장의 한마디가 비어 있어요.'}
+            {previewNotes || '방장의 한마디가 비어 있어요.'}
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 14, paddingTop: 14, borderTop: '1px solid var(--line)' }}>
-            <Avatar name="강민지" size={28} />
-            <span style={{ fontSize: 13, color: 'var(--ink-2)' }}>방장 · <b>강민지</b></span>
+            <Avatar name={hostName} size={28} />
+            <span style={{ fontSize: 13, color: 'var(--ink-2)' }}>방장 · <b>{hostName}</b></span>
             <span style={{ marginLeft: 'auto', fontSize: 12, color: 'var(--ink-3)', fontWeight: 600 }}>1/{capacity} 모집중</span>
           </div>
         </div>
@@ -596,8 +701,8 @@ export function CreateRoomStep3Screen() {
         {/* Summary */}
         <div style={{ background: 'var(--surface)', borderRadius: 16, padding: 4 }}>
           {[
-          { l: '기본 정보', v: `${draft.title || DEFAULT_CREATE_ROOM_DRAFT.title} · ${draft.dorm} ${draft.roomSize}`, i: 1 },
-          { l: '방 체크리스트', v: '생활 패턴 14개 · 추가 규칙 9개 작성됨', i: 2 }].
+          { l: '기본 정보', v: `${previewTitle || '제목 미입력'} · ${draft.dorm} ${draft.roomSize}`, i: 1 },
+          { l: '방 체크리스트', v: '작성한 체크리스트가 반영돼요', i: 2 }].
           map((r, i, a) =>
           <div key={i} style={{
             display: 'flex', alignItems: 'center', gap: 12, padding: '14px 14px',
@@ -623,9 +728,15 @@ export function CreateRoomStep3Screen() {
         <div style={{ height: 110 }} />
       </div>
 
+      {submitError &&
+      <div style={{ position: 'absolute', left: 16, right: 16, bottom: 78, color: 'var(--danger)', fontSize: 13, textAlign: 'center', lineHeight: 1.4 }}>
+          {submitError}
+        </div>
+      }
+
       <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, padding: '14px 16px'  , background: 'transparent', display: 'flex', gap: 8 }}>
         <button onClick={() => navigate('/rooms/create/2')} className="btn ghost" style={{ width: 80, height: 52 }}>이전</button>
-        <button onClick={() => navigate('/rooms/create/success')} className="btn full" style={{ flex: 1, height: 52 }}>모집방 올리기</button>
+        <button onClick={publishRoom} disabled={submitting || !canPublish} className="btn full" style={{ flex: 1, height: 52, opacity: submitting || !canPublish ? 0.6 : 1 }}>{submitting ? '등록 중...' : '모집방 올리기'}</button>
       </div>
     </div>);
 
@@ -638,6 +749,7 @@ export function CreateRoomScreen() {
   const selectedDorm = CREATE_ROOM_DORMS.find((d) => d.name === form.dorm) || CREATE_ROOM_DORMS[1];
   const titleMax = 30;
   const noteMax = 180;
+  const canGoNext = form.title.trim().length > 0;
 
   React.useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -660,7 +772,7 @@ export function CreateRoomScreen() {
   return (
     <div className="screen">
       <StatusBar />
-      <TopNav title="모집방 만들기" backTo="/rooms/find" />
+      <TopNav title="모집방 만들기" backTo="/rooms/find" collapsible={false} />
 
       <div style={{ padding: '0 20px 16px' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, color: 'var(--ink-3)', marginBottom: 6, fontWeight: 600 }}>
@@ -777,11 +889,11 @@ export function CreateRoomScreen() {
           <div>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
               <label style={{ fontSize: 13, color: 'var(--ink-3)', fontWeight: 600 }}>방장의 한마디 <span style={{ color: 'var(--ink-4)', fontWeight: 500 }}>(선택)</span></label>
-              <span style={{ fontSize: 12, color: 'var(--ink-3)' }}>{form.note.length} / {noteMax}</span>
+              <span style={{ fontSize: 12, color: 'var(--ink-3)' }}>{(form.notes || '').length} / {noteMax}</span>
             </div>
             <textarea
-              value={form.note}
-              onChange={(e) => update('note', e.target.value)}
+              value={form.notes || ''}
+              onChange={(e) => update('notes', e.target.value)}
               maxLength={noteMax}
               placeholder="예: 생활 패턴이 잘 맞는 분이면 좋아요."
               style={{
@@ -806,7 +918,7 @@ export function CreateRoomScreen() {
       </div>
 
       <div style={{ padding: '14px 16px'  , background: 'transparent' }}>
-        <button onClick={() => navigate('/rooms/create/2')} className="btn full" style={{ height: 52 }}>다음</button>
+        <button onClick={() => { if (canGoNext) navigate('/rooms/create/2'); }} disabled={!canGoNext} className="btn full" style={{ height: 52, opacity: canGoNext ? 1 : 0.45 }}>다음</button>
       </div>
     </div>);
 
@@ -815,41 +927,40 @@ export function CreateRoomScreen() {
 // ─── Applicant detail (host viewing applicant's checklist) ──
 export function ApplicantDetailScreen() {
   const navigate = useNavigate();
+  const { state } = useLocation();
+  const applicant = state?.applicant;
+  const roomNo = state?.roomNo;
   const [confirmAction, setConfirmAction] = React.useState(null);
-  // roomNo / applicantUserNo는 이 화면이 서버 데이터를 보유하게 되면 채운다 (방/신청 도메인 연동 계획으로 이관).
-  const openDirectChat = (roomNo, applicantUserNo) => {
-    getOrCreateDirectChatRoom(roomNo, applicantUserNo)
+
+  const openDirectChat = () => {
+    if (!roomNo || !applicant?.userNo) { alert('정보를 불러올 수 없어요.'); return; }
+    getOrCreateDirectChatRoom(roomNo, applicant.userNo)
       .then((chatRoomNo) => navigate('/chat/dm/' + chatRoomNo))
       .catch((e) => alert(e?.message || '채팅방을 열 수 없어요.'));
   };
-  const ITEMS = [
-  { cat: '생활 패턴', rows: [
-    { q: '취침', room: '23시 – 01시', other: '23시 – 01시', match: true },
-    { q: '기상', room: '07시 – 09시', other: '07시 – 08시', match: true },
-    { q: '귀가', room: '고정적', other: '고정적', match: true },
-    { q: '청소', room: '주기적', other: '주기적', match: true },
-    { q: '방에서 전화', room: '가능', other: '가능', match: true },
-    { q: '잠귀', room: '어두움', other: '어두움', match: true },
-    { q: '잠버릇', room: '약함', other: '약함', match: true },
-    { q: '코골이', room: '약함~없음', other: '약함~없음', match: true },
-    { q: '샤워시간', room: '저녁', other: '아침', match: false },
-    { q: '방에서 취식', room: '가능+환기필수', other: '가능', match: false },
-    { q: '소등', room: '23시 이후', other: '23시 이후', match: true },
-    { q: '본가 주기', room: '2주', other: '매주', match: false },
-    { q: '흡연', room: '비흡연', other: '비흡연', match: true },
-    { q: '냉장고', room: '협의 후 결정', other: '협의 후 결정', match: true }]
-  },
-  { cat: '추가 규칙', rows: [
-    { q: '드라이기 제한', room: '12–19시 사용 제한', other: '00–06시 사용 제한', match: false },
-    { q: '알람', room: '진동', other: '진동', match: true },
-    { q: '이어폰', room: '항상', other: '항상', match: true },
-    { q: '키스킨', room: '유동적', other: '유동적', match: true },
-        { q: '무소음 마우스', room: '사용', other: '미사용', match: false },
-    { q: '더위', room: '중간', other: '중간', match: true },
-    { q: '추위', room: '중간', other: '중간', match: true },
-    { q: '공부', room: '유동적', other: '기숙사 안', match: false },
-    { q: '쓰레기통', room: '개별', other: '개별', match: true }]
-  }];
+
+  const completeDecision = () => {
+    if (!confirmAction || !applicant) return;
+    const call = confirmAction === 'accept'
+      ? approveApplication(roomNo, applicant.requestNo)
+      : rejectApplication(applicant.requestNo);
+    call
+      .then(() => navigate(confirmAction === 'accept' ? '/rooms/members' : '/rooms/applicants'))
+      .catch((e) => alert(e?.message || '처리 중 오류가 발생했어요.'));
+  };
+
+  if (!applicant) {
+    return (
+      <div className="screen">
+        <StatusBar />
+        <TopNav title="신청자 정보" backTo="/rooms/applicants" />
+        <div style={{ padding: 32, textAlign: 'center', color: 'var(--ink-3)', fontSize: 14 }}>신청자 정보를 불러올 수 없어요.</div>
+      </div>
+    );
+  }
+
+  const displayName = applicant.nickname || applicant.name;
+  const displayMeta = [applicant.major, applicant.grade ? applicant.grade + '학년' : null].filter(Boolean).join(' ');
 
   return (
     <div className="screen">
@@ -857,110 +968,73 @@ export function ApplicantDetailScreen() {
       <TopNav title="신청자 정보" backTo="/rooms/applicants" />
 
       <div className="scroll">
-        {/* Profile header */}
         <div style={{ padding: '0 20px 16px', display: 'flex', alignItems: 'center', gap: 16 }}>
-          <Avatar name="지원" size={64} style={{ fontSize: 26 }} />
+          <Avatar name={displayName} size={64} style={{ fontSize: 26 }} />
           <div style={{ flex: 1 }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-              <span style={{ fontSize: 19, fontWeight: 700 }}>지원</span>
+              <span style={{ fontSize: 19, fontWeight: 700 }}>{displayName}</span>
             </div>
-            <div style={{ fontSize: 13, color: 'var(--ink-3)', marginTop: 2 }}>컴공 22</div>
-            <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 4 }}>2026.05.21 10:42 신청</div>
-          </div>
-        </div>
-
-        {/* Match summary */}
-        <div style={{ margin: '0 16px 16px' }} className="card">
-          <div style={{ display: 'flex', alignItems: 'center', gap: 14, padding: 6 }}>
-            <div style={{ width: 40, height: 40, borderRadius: 11, background: 'var(--brand)', color: 'white', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-              <Icon.check size={20} weight={2.6} />
-            </div>
-            <div style={{ flex: 1 }}>
-              <div style={{ fontSize: 14, fontWeight: 700 }}>방과 잘 맞아요</div>
-              <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 3 }}>10개 항목 중 7개 일치</div>
-            </div>
-          </div>
-        </div>
-
-        {/* Message */}
-        <div className="h-section"><h2>신청 메시지</h2></div>
-        <div className="card" style={{ fontSize: 14, lineHeight: 1.6, color: 'var(--ink-2)', margin: '0 16px', padding: 16 }}>
-          안녕하세요! 컴공 22학번 안녕하세요! 조용히 지내고 체크리스트 매칭도 잘 맞을 것 같아서 신청 드립니다. 잘 부탁드려요!
-        </div>
-
-        {/* Checklist comparison */}
-        <div className="h-section">
-          <h2>체크리스트 비교</h2>
-        </div>
-        <div style={{ margin: '0 16px', background: 'var(--surface)', borderRadius: 18, overflow: 'hidden' }}>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 84px 84px 24px', alignItems: 'center', padding: '12px 14px', fontSize: 11, fontWeight: 600, color: 'var(--ink-3)' }}>
-            <span />
-            <span style={{ textAlign: 'center' }}>방</span>
-            <span style={{ textAlign: 'center' }}>신청자</span>
-            <span />
-          </div>
-          {ITEMS.map((cat) =>
-          <div key={cat.cat}>
-              <div style={{ padding: '8px 14px 6px', fontSize: 11, fontWeight: 700, color: 'var(--ink-2)', background: 'var(--surface-2)' }}>{cat.cat}</div>
-              {cat.rows.map((it, i) =>
-            <div key={i} style={{ display: 'grid', gridTemplateColumns: '1fr 84px 84px 24px', alignItems: 'center', padding: '12px 14px', borderBottom: '1px solid var(--line)', fontSize: 13 }}>
-                  <span style={{ color: 'var(--ink-2)' }}>{it.q}</span>
-                  <span style={{ textAlign: 'center', fontWeight: 600 }}>{it.room}</span>
-                  <span style={{ textAlign: 'center', fontWeight: 600, color: it.match ? 'var(--ink)' : 'var(--ink-3)' }}>{it.other}</span>
-                  <span style={{ display: 'flex', justifyContent: 'flex-end' }}>
-                    {it.match ?
-                <span style={{ width: 20, height: 20, borderRadius: '50%', background: 'var(--brand)', color: 'white', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Icon.check size={12} weight={3} /></span> :
-                <span style={{ width: 20, height: 20, borderRadius: '50%', background: 'var(--surface-2)', color: 'var(--ink-3)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700 }}>−</span>}
-                  </span>
-                </div>
+            {displayMeta && <div style={{ fontSize: 13, color: 'var(--ink-3)', marginTop: 2 }}>{displayMeta}</div>}
+            {applicant.createdAt && (
+              <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 4 }}>
+                {new Date(applicant.createdAt).toLocaleDateString('ko-KR', { year: 'numeric', month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' })} 신청
+              </div>
             )}
-            </div>
-          )}
+          </div>
         </div>
+
+        {(applicant.introduction || applicant.additionalMessage) && (
+          <>
+            <div className="h-section"><h2>신청 메시지</h2></div>
+            <div className="card" style={{ fontSize: 14, lineHeight: 1.6, color: 'var(--ink-2)', margin: '0 16px', padding: 16 }}>
+              {applicant.additionalMessage || applicant.introduction}
+            </div>
+          </>
+        )}
 
         <div style={{ height: 110 }} />
       </div>
 
-	      {/* Action bar */}
-	      <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, padding: '14px 16px 30px', background: 'var(--surface)', borderTop: '1px solid var(--line)', display: 'flex', gap: 8 }}>
-	        <button onClick={() => setConfirmAction('reject')} className="btn ghost" style={{ flex: 1, height: 52 }}>거절</button>
-	        <button onClick={() => openDirectChat(null, null)} className="btn ghost" style={{ width: 52, height: 52, padding: 0 }}><Icon.chat size={22} /></button>
-	        <button onClick={() => setConfirmAction('accept')} className="btn full" style={{ flex: 1, height: 52 }}>수락</button>
-	      </div>
-	      {confirmAction && (
-	        <div onClick={() => setConfirmAction(null)} style={{ position: 'absolute', inset: 0, zIndex: 20, background: 'rgba(23,24,28,0.28)', display: 'flex', alignItems: 'flex-end' }}>
-	          <div onClick={(e) => e.stopPropagation()} style={{ width: '100%', background: 'var(--surface)', borderRadius: '22px 22px 0 0', padding: '10px 16px 30px', boxShadow: '0 -16px 40px rgba(23,24,28,0.14)' }}>
-	            <div style={{ width: 38, height: 4, borderRadius: 99, background: 'var(--line-2)', margin: '0 auto 14px' }} />
-	            <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '0 2px 18px' }}>
-	              <Avatar name="지원" size={44} />
-	              <div style={{ flex: 1, minWidth: 0 }}>
-	                <div style={{ fontSize: 18, fontWeight: 700, letterSpacing: '-0.3px' }}>
-	                  {confirmAction === 'accept' ? '신청을 수락할까요?' : '신청을 거절할까요?'}
-	                </div>
-	                <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 4 }}>지원 · 컴공 22</div>
-	              </div>
-	            </div>
-	            <div style={{ borderRadius: 14, background: 'var(--surface-2)', padding: 14, fontSize: 12, lineHeight: 1.5, color: 'var(--ink-2)', marginBottom: 12 }}>
-	              {confirmAction === 'accept'
-	                ? '수락하면 지원님이 방 멤버로 이동하고 신청은 완료 처리돼요.'
-	                : '거절하면 지원님의 신청이 목록에서 사라져요. 다시 되돌릴 수 없어요.'}
-	            </div>
-	            <div style={{ display: 'flex', gap: 8 }}>
-	              <button type="button" onClick={() => setConfirmAction(null)} className="btn ghost" style={{ width: 92, height: 52 }}>취소</button>
-	              <button
-	                type="button"
-	                onClick={() => navigate(confirmAction === 'accept' ? '/rooms/members' : '/rooms/applicants')}
-	                className="btn full"
-	                style={{ flex: 1, height: 52, background: confirmAction === 'accept' ? 'var(--brand)' : 'var(--danger)' }}
-	              >
-	                {confirmAction === 'accept' ? '수락하기' : '거절하기'}
-	              </button>
-	            </div>
-	          </div>
-	        </div>
-	      )}
-	    </div>);
+      <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, padding: '14px 16px 30px', background: 'var(--surface)', borderTop: '1px solid var(--line)', display: 'flex', gap: 8 }}>
+        <button onClick={() => setConfirmAction('reject')} className="btn ghost" style={{ flex: 1, height: 52 }}>거절</button>
+        <button onClick={openDirectChat} className="btn ghost" style={{ width: 52, height: 52, padding: 0 }}><Icon.chat size={22} /></button>
+        <button onClick={() => setConfirmAction('accept')} className="btn full" style={{ flex: 1, height: 52 }}>수락</button>
+      </div>
 
+      {confirmAction && (
+        <div onClick={() => setConfirmAction(null)} style={{ position: 'absolute', inset: 0, zIndex: 20, background: 'rgba(23,24,28,0.28)', display: 'flex', alignItems: 'flex-end' }}>
+          <div onClick={(e) => e.stopPropagation()} style={{ width: '100%', background: 'var(--surface)', borderRadius: '22px 22px 0 0', padding: '10px 16px 30px', boxShadow: '0 -16px 40px rgba(23,24,28,0.14)' }}>
+            <div style={{ width: 38, height: 4, borderRadius: 99, background: 'var(--line-2)', margin: '0 auto 14px' }} />
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '0 2px 18px' }}>
+              <Avatar name={displayName} size={44} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 18, fontWeight: 700, letterSpacing: '-0.3px' }}>
+                  {confirmAction === 'accept' ? '신청을 수락할까요?' : '신청을 거절할까요?'}
+                </div>
+                <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 4 }}>{displayName}{displayMeta ? ' · ' + displayMeta : ''}</div>
+              </div>
+            </div>
+            <div style={{ borderRadius: 14, background: 'var(--surface-2)', padding: 14, fontSize: 12, lineHeight: 1.5, color: 'var(--ink-2)', marginBottom: 12 }}>
+              {confirmAction === 'accept'
+                ? `수락하면 ${displayName}님이 방 멤버로 이동하고 신청은 완료 처리돼요.`
+                : `거절하면 ${displayName}님의 신청이 목록에서 사라져요. 다시 되돌릴 수 없어요.`}
+            </div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button type="button" onClick={() => setConfirmAction(null)} className="btn ghost" style={{ width: 92, height: 52 }}>취소</button>
+              <button
+                type="button"
+                onClick={completeDecision}
+                className="btn full"
+                style={{ flex: 1, height: 52, background: confirmAction === 'accept' ? 'var(--brand)' : 'var(--danger)' }}
+              >
+                {confirmAction === 'accept' ? '수락하기' : '거절하기'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }
 
 // ─── Notice list/detail ─────────────────────────────────────
@@ -1829,7 +1903,18 @@ export function ApplyMessageScreen() {
   const navigate = useNavigate();
   const { id = '1' } = useParams();
   const [message, setMessage] = React.useState('');
+  const [submitting, setSubmitting] = React.useState(false);
+  const [submitError, setSubmitError] = React.useState('');
   const maxLength = 300;
+
+  const handleSubmit = () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setSubmitError('');
+    submitRoomApplication(id, message)
+      .then(() => navigate('/apply/success', { state: { roomNo: id } }))
+      .catch((e) => { setSubmitError(e?.message || '신청에 실패했어요.'); setSubmitting(false); });
+  };
   const suggestions = [
     '안녕하세요! 체크리스트가 잘 맞는 것 같아서 신청드립니다.',
     '조용히 지내는 편이고 청소 규칙도 잘 맞출 수 있어요.',
@@ -1929,10 +2014,18 @@ export function ApplyMessageScreen() {
         </div>
       </div>
 
+      {submitError && (
+        <div style={{ padding: '8px 0', fontSize: 13, color: 'var(--danger)', textAlign: 'center' }}>{submitError}</div>
+      )}
       <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, padding: '14px 16px 30px', background: 'var(--surface)', borderTop: '1px solid var(--line)', display: 'flex', gap: 8 }}>
         <button onClick={() => navigate(`/rooms/${id}`)} className="btn ghost" style={{ width: 84, height: 52 }}>취소</button>
-        <button onClick={() => navigate('/apply/success')} className="btn full" style={{ flex: 1, height: 52 }}>
-          신청 보내기
+        <button
+          onClick={handleSubmit}
+          disabled={submitting}
+          className="btn full"
+          style={{ flex: 1, height: 52, opacity: submitting ? 0.6 : 1 }}
+        >
+          {submitting ? '신청 중...' : '신청 보내기'}
         </button>
       </div>
     </div>
@@ -1942,8 +2035,10 @@ export function ApplyMessageScreen() {
 // ─── Apply success ──────────────────────────────────────────
 export function ApplySuccessScreen() {
   const navigate = useNavigate();
-  // roomNo는 이 화면이 서버 데이터를 보유하게 되면 채운다 (방/신청 도메인 연동 계획으로 이관).
-  const openDirectChat = (roomNo) => {
+  const { state } = useLocation();
+  const roomNo = state?.roomNo;
+  const openDirectChat = () => {
+    if (!roomNo) { alert('방 정보를 불러올 수 없어요.'); return; }
     getOrCreateDirectChatRoom(roomNo, getCachedUserNo())
       .then((chatRoomNo) => navigate('/chat/dm/' + chatRoomNo))
       .catch((e) => alert(e?.message || '채팅방을 열 수 없어요.'));
@@ -1988,7 +2083,7 @@ export function ApplySuccessScreen() {
       </div>
 
       <div style={{ padding: '0 16px 30px', display: 'flex', flexDirection: 'column', gap: 8 }}>
-        <button onClick={() => openDirectChat(null)} className="btn full" style={{ height: 52 }}>방장과 채팅하기</button>
+        <button onClick={() => openDirectChat()} className="btn full" style={{ height: 52 }}>방장과 채팅하기</button>
         <button onClick={() => navigate('/rooms/find')} className="btn full ghost" style={{ height: 52 }}>다른 방 둘러보기</button>
       </div>
     </div>);
@@ -1998,10 +2093,9 @@ export function ApplySuccessScreen() {
 // ─── Create Room Success ─────────────────────────────────────
 export function CreateRoomSuccessScreen() {
   const navigate = useNavigate();
-  const draft = typeof window !== 'undefined'
-    ? JSON.parse(window.sessionStorage.getItem('createRoomDraft') || '{}')
-    : {};
-  const title = draft.title || '아침형 룸메 구해요';
+  const { state } = useLocation();
+  const draft = state?.draft || readCreateRoomDraft();
+  const title = draft.title || '모집방';
   const dorm = draft.dorm || '2생활관';
   const roomSize = draft.roomSize || '4인실';
 

--- a/src/features/checklist/pages/Details.jsx
+++ b/src/features/checklist/pages/Details.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Icon, StatusBar, Avatar, goBack } from '../../../shared/components';
-import { logout as logoutUser } from '../../../shared/api/auth';
-import { ChatBubble, ChatComposer, ChatAttachmentCard } from '../../chat';
+import { logout as logoutUser, getCachedUserNo } from '../../../shared/api/auth';
+import { ChatMessageItem, ChatComposer } from '../../chat';
+import { getOrCreateDirectChatRoom, loadChatMessages, markChatRoomRead, leaveChatRoom } from '../../../shared/api/chat';
+import { subscribe, publish } from '../../../shared/api/chatSocket';
+import { applyReadReceipt, appendMessage } from '../../chat/unreadSync';
 
 // details.jsx — Detail screens for each tab
 
@@ -813,6 +816,12 @@ export function CreateRoomScreen() {
 export function ApplicantDetailScreen() {
   const navigate = useNavigate();
   const [confirmAction, setConfirmAction] = React.useState(null);
+  // roomNo / applicantUserNo는 이 화면이 서버 데이터를 보유하게 되면 채운다 (방/신청 도메인 연동 계획으로 이관).
+  const openDirectChat = (roomNo, applicantUserNo) => {
+    getOrCreateDirectChatRoom(roomNo, applicantUserNo)
+      .then((chatRoomNo) => navigate('/chat/dm/' + chatRoomNo))
+      .catch((e) => alert(e?.message || '채팅방을 열 수 없어요.'));
+  };
   const ITEMS = [
   { cat: '생활 패턴', rows: [
     { q: '취침', room: '23시 – 01시', other: '23시 – 01시', match: true },
@@ -915,7 +924,7 @@ export function ApplicantDetailScreen() {
 	      {/* Action bar */}
 	      <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, padding: '14px 16px 30px', background: 'var(--surface)', borderTop: '1px solid var(--line)', display: 'flex', gap: 8 }}>
 	        <button onClick={() => setConfirmAction('reject')} className="btn ghost" style={{ flex: 1, height: 52 }}>거절</button>
-	        <button onClick={() => navigate('/chat/dm')} className="btn ghost" style={{ width: 52, height: 52, padding: 0 }}><Icon.chat size={22} /></button>
+	        <button onClick={() => openDirectChat(null, null)} className="btn ghost" style={{ width: 52, height: 52, padding: 0 }}><Icon.chat size={22} /></button>
 	        <button onClick={() => setConfirmAction('accept')} className="btn full" style={{ flex: 1, height: 52 }}>수락</button>
 	      </div>
 	      {confirmAction && (
@@ -1705,11 +1714,65 @@ export function SupportScreen() {
 // ─── 1:1 DM chat ────────────────────────────────────────────
 export function ChatDMScreen() {
   const navigate = useNavigate();
+  const { chatRoomNo } = useParams();
+  const myUserNo = React.useMemo(() => getCachedUserNo(), []);
   const [menuOpen, setMenuOpen] = React.useState(false);
-  const [sentMessages, setSentMessages] = React.useState([]);
-  const sendDMMessage = (message) => {
-    setSentMessages((items) => [...items, { ...message, unread: 1 }]);
+  const [messages, setMessages] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const scrollRef = React.useRef(null);
+
+  React.useEffect(() => {
+    if (!chatRoomNo) return;
+    let alive = true;
+    setLoading(true);
+    loadChatMessages(chatRoomNo)
+      .then((page) => {
+        if (!alive) return;
+        setMessages((page?.items || []).slice().reverse());
+        setLoading(false);
+        markChatRoomRead(chatRoomNo).catch(() => {});
+      })
+      .catch(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, [chatRoomNo]);
+
+  React.useEffect(() => {
+    if (!chatRoomNo) return;
+    let unsubMsg = () => {};
+    let unsubRead = () => {};
+    let alive = true;
+
+    subscribe(`/topic/chat-room/${chatRoomNo}`, (incoming) => {
+      if (!alive) return;
+      setMessages((prev) => appendMessage(prev, incoming));
+      if (incoming.senderNo !== myUserNo) markChatRoomRead(chatRoomNo).catch(() => {});
+    }).then((fn) => { if (alive) unsubMsg = fn; else fn(); });
+
+    subscribe(`/topic/chat-room/${chatRoomNo}/read`, (receipt) => {
+      if (!alive) return;
+      if (receipt.readerUserNo === myUserNo) return;
+      setMessages((prev) => applyReadReceipt(prev, receipt));
+    }).then((fn) => { if (alive) unsubRead = fn; else fn(); });
+
+    return () => { alive = false; unsubMsg(); unsubRead(); };
+  }, [chatRoomNo, myUserNo]);
+
+  React.useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages]);
+
+  const sendDMMessage = (text) => {
+    publish(`/app/chat-room/${chatRoomNo}/send`, { content: text }).catch(() => {});
   };
+
+  const handleLeave = () => {
+    leaveChatRoom(chatRoomNo)
+      .then(() => { setMenuOpen(false); navigate('/chat'); })
+      .catch((e) => { alert(e?.message || '나갈 수 없어요.'); });
+  };
+
+  const partnerName = messages.find((m) => m.senderNo !== myUserNo)?.senderNickname || '상대방';
 
   return (
     <div className="screen" style={{ background: '#EDEEF1' }}>
@@ -1717,87 +1780,38 @@ export function ChatDMScreen() {
         <StatusBar />
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 12px 12px' }}>
           <button onClick={() => goBack(navigate, '/chat')} style={{ background: 'transparent', border: 0, padding: 6, color: 'var(--ink)', cursor: 'pointer' }}><Icon.back /></button>
-		          <Avatar name="지원" size={36} style={{ fontSize: 14 }} />
-	          <div style={{ flex: 1, minWidth: 0 }}>
-	            <div style={{ fontSize: 15, fontWeight: 700 }}>지원</div>
-	          </div>
+          <Avatar name={partnerName.slice(0, 1)} size={36} style={{ fontSize: 14 }} />
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 15, fontWeight: 700 }}>{partnerName}</div>
+          </div>
           <button onClick={() => setMenuOpen(true)} aria-label="채팅방 메뉴" style={{ background: 'transparent', border: 0, padding: 6, color: 'var(--ink)', cursor: 'pointer' }}>
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" /></svg>
           </button>
         </div>
       </div>
 
-      {/* Context card — applicant info */}
-      <div style={{ padding: '10px 12px 0' }}>
-        <div onClick={() => navigate('/rooms/applicants/1')} className="card" style={{ display: 'flex', alignItems: 'center', gap: 10, padding: 12, cursor: 'pointer' }}>
-          <div style={{ width: 36, height: 36, borderRadius: 10, background: 'var(--brand-soft)', color: 'var(--brand-deep)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Icon.door size={18} />
-          </div>
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--ink)' }}>아침형 룸메 구해요</div>
-            <div style={{ fontSize: 11, color: 'var(--ink-3)', marginTop: 1 }}>지원님이 신청한 모집방</div>
-          </div>
-          <span className="chip line" style={{ fontSize: 11 }}>신청자 정보</span>
-        </div>
-      </div>
-
-      <div className="scroll" style={{ padding: '12px 12px 8px' }}>
-        <div style={{ textAlign: 'center', margin: '4px 0 14px' }}>
-          <span style={{ fontSize: 11, color: 'var(--ink-3)', background: 'rgba(0,0,0,0.05)', padding: '4px 12px', borderRadius: 99 }}>2026년 5월 21일 목요일</span>
-        </div>
-
-        <ChatBubble side="left" name="지원" time="오후 04:18">안녕하세요! 신청 드렸어요 :)</ChatBubble>
-        <ChatBubble side="left" name="지원" time="오후 04:18" showAvatar={false} showName={false}>
-          체크리스트 보니까 잘 맞을 것 같아서요.
-        </ChatBubble>
-
-        <div style={{ height: 8 }} />
-        <ChatBubble side="right" time="오후 04:25" unread={1}>반가워요! 체크리스트 확인했어요</ChatBubble>
-        <ChatBubble side="right" time="오후 04:26" withTail={false} unread={1}>
-          평일 저녁은 보통 몇 시쯤 들어오세요?
-        </ChatBubble>
-
-        <div style={{ height: 8 }} />
-        <ChatBubble side="left" name="지원" time="오후 04:30">
-          학기 중엔 보통 9시쯤 들어와요. 시험 기간엔 새벽까지 도서관에 있고요.
-        </ChatBubble>
-        <ChatBubble side="left" name="지원" time="오후 04:31" showAvatar={false} showName={false}>
-          저녁은 거의 밖에서 해결합니다!
-        </ChatBubble>
-        {sentMessages.map((message) => (
-          <ChatBubble key={message.id} side="right" time={message.time} unread={message.unread}>
-            {message.attachment && <ChatAttachmentCard attachment={message.attachment} mine />}
-            {message.text && <div style={{ marginTop: message.attachment ? 8 : 0 }}>{message.text}</div>}
-          </ChatBubble>
+      <div className="scroll" ref={scrollRef} style={{ padding: '12px 12px 8px' }}>
+        {loading && <div style={{ textAlign: 'center', color: 'var(--ink-3)', fontSize: 13, padding: 24 }}>불러오는 중…</div>}
+        {!loading && messages.length === 0 && (
+          <div style={{ textAlign: 'center', color: 'var(--ink-3)', fontSize: 13, padding: 24 }}>첫 메시지를 보내보세요.</div>
+        )}
+        {messages.map((m) => (
+          <ChatMessageItem key={m.messageNo} message={m} myUserNo={myUserNo} />
         ))}
       </div>
 
-      <ChatComposer onSend={sendDMMessage} />
+      <ChatComposer onSend={sendDMMessage} disabled={loading} />
       {menuOpen && (
         <div onClick={() => setMenuOpen(false)} style={{ position: 'absolute', inset: 0, zIndex: 20, background: 'rgba(23,24,28,0.28)', display: 'flex', alignItems: 'flex-end' }}>
           <div onClick={(e) => e.stopPropagation()} style={{ width: '100%', background: 'var(--surface)', borderRadius: '22px 22px 0 0', padding: '10px 16px 30px', boxShadow: '0 -16px 40px rgba(23,24,28,0.14)' }}>
             <div style={{ width: 38, height: 4, borderRadius: 99, background: 'var(--line-2)', margin: '0 auto 14px' }} />
             <div style={{ padding: '0 2px 14px' }}>
               <div style={{ fontSize: 18, fontWeight: 700, letterSpacing: '-0.3px' }}>채팅방 메뉴</div>
-              <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 4 }}>지원님과의 대화</div>
+              <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 4 }}>{partnerName}님과의 대화</div>
             </div>
             <button
               type="button"
-              onClick={() => {
-                setMenuOpen(false);
-                navigate('/rooms/applicants/1');
-              }}
-              style={{ width: '100%', minHeight: 52, border: 0, borderRadius: 14, background: 'var(--surface-2)', color: 'var(--ink)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 14px', fontFamily: 'inherit', fontSize: 15, fontWeight: 700, cursor: 'pointer', marginBottom: 8 }}
-            >
-              <span>신청자 정보 보기</span>
-              <Icon.chevron size={14} />
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                setMenuOpen(false);
-                navigate('/chat');
-              }}
+              onClick={handleLeave}
               style={{ width: '100%', minHeight: 52, border: 0, borderRadius: 14, background: 'rgba(226,69,60,0.08)', color: 'var(--danger)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 14px', fontFamily: 'inherit', fontSize: 15, fontWeight: 700, cursor: 'pointer' }}
             >
               <span>대화방 나가기</span>
@@ -1806,8 +1820,8 @@ export function ChatDMScreen() {
           </div>
         </div>
       )}
-    </div>);
-
+    </div>
+  );
 }
 
 // ─── Apply message ──────────────────────────────────────────
@@ -1928,6 +1942,12 @@ export function ApplyMessageScreen() {
 // ─── Apply success ──────────────────────────────────────────
 export function ApplySuccessScreen() {
   const navigate = useNavigate();
+  // roomNo는 이 화면이 서버 데이터를 보유하게 되면 채운다 (방/신청 도메인 연동 계획으로 이관).
+  const openDirectChat = (roomNo) => {
+    getOrCreateDirectChatRoom(roomNo, getCachedUserNo())
+      .then((chatRoomNo) => navigate('/chat/dm/' + chatRoomNo))
+      .catch((e) => alert(e?.message || '채팅방을 열 수 없어요.'));
+  };
 
   return (
     <div className="screen" style={{ background: 'var(--surface)' }}>
@@ -1968,7 +1988,7 @@ export function ApplySuccessScreen() {
       </div>
 
       <div style={{ padding: '0 16px 30px', display: 'flex', flexDirection: 'column', gap: 8 }}>
-        <button onClick={() => navigate('/chat/dm')} className="btn full" style={{ height: 52 }}>방장과 채팅하기</button>
+        <button onClick={() => openDirectChat(null)} className="btn full" style={{ height: 52 }}>방장과 채팅하기</button>
         <button onClick={() => navigate('/rooms/find')} className="btn full ghost" style={{ height: 52 }}>다른 방 둘러보기</button>
       </div>
     </div>);

--- a/src/features/checklist/pages/Details.jsx
+++ b/src/features/checklist/pages/Details.jsx
@@ -1804,7 +1804,6 @@ export function ChatDMScreen() {
         if (!alive) return;
         setMessages((page?.items || []).slice().reverse());
         setLoading(false);
-        markChatRoomRead(chatRoomNo).catch(() => {});
       })
       .catch(() => { if (alive) setLoading(false); });
     return () => { alive = false; };
@@ -1816,17 +1815,24 @@ export function ChatDMScreen() {
     let unsubRead = () => {};
     let alive = true;
 
-    subscribe(`/topic/chat-room/${chatRoomNo}`, (incoming) => {
+    const pMsg = subscribe(`/topic/chat-room/${chatRoomNo}`, (incoming) => {
       if (!alive) return;
       setMessages((prev) => appendMessage(prev, incoming));
       if (incoming.senderNo !== myUserNo) markChatRoomRead(chatRoomNo).catch(() => {});
-    }).then((fn) => { if (alive) unsubMsg = fn; else fn(); });
+    });
 
-    subscribe(`/topic/chat-room/${chatRoomNo}/read`, (receipt) => {
+    const pRead = subscribe(`/topic/chat-room/${chatRoomNo}/read`, (receipt) => {
       if (!alive) return;
-      if (receipt.readerUserNo === myUserNo) return;
       setMessages((prev) => applyReadReceipt(prev, receipt));
-    }).then((fn) => { if (alive) unsubRead = fn; else fn(); });
+    });
+
+    // 두 구독이 모두 준비된 뒤 읽음 처리 — 이 시점에 서버 broadcast를 수신할 수 있음
+    Promise.all([pMsg, pRead]).then(([fnMsg, fnRead]) => {
+      if (!alive) { fnMsg(); fnRead(); return; }
+      unsubMsg = fnMsg;
+      unsubRead = fnRead;
+      markChatRoomRead(chatRoomNo).catch(() => {});
+    });
 
     return () => { alive = false; unsubMsg(); unsubRead(); };
   }, [chatRoomNo, myUserNo]);
@@ -1909,9 +1915,10 @@ export function ApplyMessageScreen() {
 
   const handleSubmit = () => {
     if (submitting) return;
+    if (!message.trim()) { setSubmitError('신청 메시지를 입력해주세요.'); return; }
     setSubmitting(true);
     setSubmitError('');
-    submitRoomApplication(id, message)
+    submitRoomApplication(id, message.trim())
       .then(() => navigate('/apply/success', { state: { roomNo: id } }))
       .catch((e) => { setSubmitError(e?.message || '신청에 실패했어요.'); setSubmitting(false); });
   };

--- a/src/features/members/pages/Members.jsx
+++ b/src/features/members/pages/Members.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Icon, Avatar, StatusBar, goBack } from '../../../shared/components';
+import { loadMyRoom } from '../../../shared/api/home';
+import { getOrCreateDirectChatRoom, loadMyChatRooms } from '../../../shared/api/chat';
+import { loadMyRoommates } from '../../../shared/api/room';
+import { normalizeRoom, roommateToMember } from '../../rooms/roomData';
 
 // members.jsx — 룸메이트 멤버 화면 (방장 시점)
 // 현재 방의 멤버 목록 + 각자의 개인 체크리스트를 펼쳐서 비교 가능
@@ -74,9 +78,10 @@ export const MEMBER_CHECKLISTS = [
   },
 ];
 
-export function MemberCard({ m, defaultOpen = false }) {
+export function MemberCard({ m, defaultOpen = false, onOpenChat }) {
   const [open, setOpen] = React.useState(defaultOpen);
   const navigate = useNavigate();
+  const hasChecklist = (m.checklist || []).length > 0;
 
   return (
     <div className="card" style={{ padding: 16, marginBottom: 10 }}>
@@ -97,12 +102,14 @@ export function MemberCard({ m, defaultOpen = false }) {
           <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 2 }}>{m.dept}</div>
         </div>
         {!m.isMe && (
-          <button onClick={() => navigate('/chat/dm')} title="채팅" style={{ width: 36, height: 36, borderRadius: 10, border: 0, background: 'var(--surface-2)', color: 'var(--ink-2)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
+          <button onClick={() => onOpenChat ? onOpenChat(m) : navigate('/chat')} title="채팅" style={{ width: 36, height: 36, borderRadius: 10, border: 0, background: 'var(--surface-2)', color: 'var(--ink-2)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
             <Icon.chat size={18}/>
           </button>
         )}
       </div>
 
+      {hasChecklist && (
+      <>
       {/* Expandable checklist */}
       <div style={{
         display: 'grid',
@@ -112,7 +119,7 @@ export function MemberCard({ m, defaultOpen = false }) {
       }}>
         <div style={{ overflow: 'hidden' }}>
           <div style={{ background: 'var(--surface)', borderRadius: 12, overflow: 'hidden', border: '1px solid var(--line)' }}>
-            {m.checklist.map((cat, ci) => (
+            {(m.checklist || []).map((cat, ci) => (
               <React.Fragment key={ci}>
                 <div style={{
                   background: 'var(--surface-2)',
@@ -152,12 +159,53 @@ export function MemberCard({ m, defaultOpen = false }) {
           <Icon.chevron size={14}/>
         </span>
       </button>
+      </>
+      )}
     </div>
   );
 }
 
 export function MembersScreen() {
   const navigate = useNavigate();
+  const [room, setRoom] = React.useState(null);
+  const [members, setMembers] = React.useState([]);
+  const [groupChatRoomNo, setGroupChatRoomNo] = React.useState(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState('');
+
+  React.useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    setError('');
+    Promise.all([
+      loadMyRoom(),
+      loadMyRoommates().catch(() => []),
+      loadMyChatRooms().catch(() => []),
+    ])
+      .then(([roomData, roommateList, chatRooms]) => {
+        if (!mounted) return;
+        const normalized = normalizeRoom(roomData);
+        setRoom(normalized);
+        setMembers(Array.isArray(roommateList) ? roommateList.map(roommateToMember) : []);
+        const chatList = Array.isArray(chatRooms) ? chatRooms : chatRooms?.items || [];
+        const found = chatList.find((chatRoom) => chatRoom.chatRoomType === 'GROUP' && String(chatRoom.roomNo) === String(roomData.roomNo));
+        setGroupChatRoomNo(found?.chatRoomNo || null);
+      })
+      .catch(() => { if (mounted) setError('룸메이트 정보를 불러오지 못했어요.'); })
+      .finally(() => { if (mounted) setLoading(false); });
+    return () => { mounted = false; };
+  }, []);
+
+  const openDirectChat = (member) => {
+    if (!room?.roomNo || !member.userNo) return;
+    getOrCreateDirectChatRoom(room.roomNo, member.userNo)
+      .then((chatRoomNo) => navigate('/chat/dm/' + chatRoomNo))
+      .catch((e) => alert(e?.message || '채팅방을 열 수 없어요.'));
+  };
+
+  const currentMembers = room?.members ?? members.length;
+  const roomCapacity = room?.capacity ?? currentMembers;
+  const openSeats = Math.max(0, roomCapacity - currentMembers);
 
   return (
     <div className="screen">
@@ -171,7 +219,7 @@ export function MembersScreen() {
       <div className="scroll" style={{ padding: '0 16px 24px' }}>
         {/* Header */}
         <div style={{ padding: '4px 4px 14px' }}>
-          <div style={{ fontSize: 22, fontWeight: 700, letterSpacing: '-0.4px' }}>현재 룸메이트 2명</div>
+          <div style={{ fontSize: 22, fontWeight: 700, letterSpacing: '-0.4px' }}>현재 룸메이트 {currentMembers}명</div>
           <div style={{ fontSize: 13, color: 'var(--ink-3)', marginTop: 4 }}>같이 사는 멤버들의 체크리스트를 확인해보세요</div>
         </div>
 
@@ -188,8 +236,8 @@ export function MembersScreen() {
         {/* Stats strip */}
         <div className="card" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', padding: 4, marginBottom: 16 }}>
           {[
-            { l: '인원', v: '2 / 4' },
-            { l: '모집 시작일', v: '2026.03.02' },
+            { l: '인원', v: `${currentMembers} / ${roomCapacity}` },
+            { l: '남은 자리', v: `${openSeats}자리` },
           ].map((s, i, a) => (
             <div key={i} style={{ textAlign: 'center', padding: '10px 0', borderRight: i === a.length - 1 ? 'none' : '1px solid var(--line)' }}>
               <div style={{ fontSize: 11, color: 'var(--ink-3)', fontWeight: 600 }}>{s.l}</div>
@@ -199,15 +247,18 @@ export function MembersScreen() {
         </div>
 
         {/* Members */}
-        {MEMBER_CHECKLISTS.map((m, i) => (
-          <MemberCard key={i} m={m} defaultOpen={false}/>
+        {loading && <div style={{ padding: 24, textAlign: 'center', color: 'var(--ink-3)', fontSize: 13 }}>불러오는 중...</div>}
+        {error && <div style={{ padding: 24, textAlign: 'center', color: 'var(--danger)', fontSize: 13 }}>{error}</div>}
+        {!loading && !error && members.map((m) => (
+          <MemberCard key={m.id} m={m} defaultOpen={false} onOpenChat={openDirectChat}/>
         ))}
 
         {/* Empty slots */}
-        <div style={{ marginTop: 4, marginBottom: 18 }}>
-          <div style={{ fontSize: 12, fontWeight: 700, color: 'var(--ink-3)', padding: '0 4px 8px', letterSpacing: '0.3px' }}>모집중 (2자리)</div>
+        {openSeats > 0 && (
+          <div style={{ marginTop: 4, marginBottom: 18 }}>
+          <div style={{ fontSize: 12, fontWeight: 700, color: 'var(--ink-3)', padding: '0 4px 8px', letterSpacing: '0.3px' }}>모집중 ({openSeats}자리)</div>
           <div style={{ display: 'flex', gap: 8 }}>
-            {[0,1].map(i => (
+            {Array.from({ length: openSeats }).map((_, i) => (
               <div key={i} className="card" style={{
                 flex: 1, padding: '20px 12px', textAlign: 'center',
                 background: 'transparent', border: '1.5px dashed var(--line-2)',
@@ -220,9 +271,10 @@ export function MembersScreen() {
             ))}
           </div>
         </div>
+        )}
 
         {/* Group chat link */}
-        <div onClick={() => navigate('/chat/group')} className="card" style={{ display: 'flex', alignItems: 'center', gap: 12, padding: 14, cursor: 'pointer' }}>
+        <div onClick={() => navigate(groupChatRoomNo ? '/chat/group/' + groupChatRoomNo : '/chat')} className="card" style={{ display: 'flex', alignItems: 'center', gap: 12, padding: 14, cursor: 'pointer' }}>
           <div style={{ width: 40, height: 40, borderRadius: 11, background: 'var(--ink)', color: 'white', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <Icon.chat size={20} solid/>
           </div>

--- a/src/features/my-room/index.js
+++ b/src/features/my-room/index.js
@@ -2,7 +2,4 @@ export {
   ApplicantsListScreen,
   RoomChecklistScreen,
   EditPostScreen,
-  APPLICANTS,
-  ROOM_VIEW_CHECKLIST,
 } from './pages/MyRoomScreens.jsx';
-

--- a/src/features/my-room/pages/MyRoomScreens.jsx
+++ b/src/features/my-room/pages/MyRoomScreens.jsx
@@ -1,42 +1,77 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Icon, StatusBar, Avatar, ClipText, goBack } from '../../../shared/components';
+import { loadMyRoom } from '../../../shared/api/home';
+import { loadApplications, approveApplication, rejectApplication, loadMyRoomRule, updateRoomTitle } from '../../../shared/api/room';
+import { getOrCreateDirectChatRoom } from '../../../shared/api/chat';
+import { normalizeRoom, roomRuleToChecklist } from '../../rooms/roomData';
 
 // myroom-screens.jsx — destination screens from My Room quick actions
 // 신청자 관리 (applicants list), 방 체크리스트 보기 (read-only), 모집글 수정
 
 // ─── 신청자 관리 (full list) ─────────────────────────────────
-export const APPLICANTS = [
-{ id: 1, name: '지원', dept: '컴공 22', tone: 'sky', match: '잘 맞아요', time: '10분 전', message: '안녕하세요! 7시 전에 일어나는 편이고 조용히 지내요.' },
-{ id: 2, name: '서연', dept: '심리 21', tone: 'plum', match: '잘 맞아요', time: '2시간 전', message: '체크리스트 확인했어요. 잘 맞을 것 같아요!' },
-{ id: 3, name: '지호', dept: '경제 23', tone: 'sand', match: '괜찮아요', time: '어제', message: '운동 좋아하지만 새벽까지 시끄럽게는 안 해요.' },
-{ id: 4, name: '지훈', dept: '국문 22', tone: 'sage', match: '괜찮아요', time: '어제', message: '평일은 거의 도서관에 있어요. 부탁드려요.' },
-{ id: 5, name: '민서', dept: '경영 24', tone: '', match: '맞춰볼 만해요', time: '2일 전', message: '신청 드립니다. 잘 부탁드려요.' }];
-
-
 export function ApplicantsListScreen() {
   const navigate = useNavigate();
-  const [filter, setFilter] = React.useState('전체');
-  const [applicants, setApplicants] = React.useState(APPLICANTS);
+  const [applicants, setApplicants] = React.useState([]);
+  const [roomNo, setRoomNo] = React.useState(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState('');
   const [confirmAction, setConfirmAction] = React.useState(null);
-  const filterOptions = ['전체', '잘 맞아요', '괜찮아요', '맞춰볼 만해요'];
-  const filteredApplicants = filter === '전체'
-    ? applicants
-    : applicants.filter((a) => a.match === filter);
 
-  const requestDecision = (applicant, action) => {
-    setConfirmAction({ applicant, action });
-  };
+  React.useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    loadMyRoom()
+      .then((room) => {
+        if (!mounted) return;
+        setRoomNo(room.roomNo);
+        return loadApplications(room.roomNo);
+      })
+      .then((list) => {
+        if (!mounted) return;
+        setApplicants(list || []);
+      })
+      .catch(() => { if (mounted) setError('신청자 목록을 불러오지 못했어요.'); })
+      .finally(() => { if (mounted) setLoading(false); });
+    return () => { mounted = false; };
+  }, []);
+
+  const requestDecision = (applicant, action) => setConfirmAction({ applicant, action });
 
   const completeDecision = () => {
     if (!confirmAction) return;
     const { applicant, action } = confirmAction;
-    setApplicants((prev) => prev.filter((a) => a.id !== applicant.id));
-    setConfirmAction(null);
-    if (action === 'accept') {
-      navigate('/rooms/members');
-    }
+    const call = action === 'accept'
+      ? approveApplication(roomNo, applicant.requestNo)
+      : rejectApplication(applicant.requestNo);
+    call
+      .then(() => {
+        setApplicants((prev) => prev.filter((a) => a.requestNo !== applicant.requestNo));
+        setConfirmAction(null);
+        if (action === 'accept') navigate('/rooms/members');
+      })
+      .catch((e) => alert(e?.message || '처리 중 오류가 발생했어요.'));
   };
+
+  const openDM = (applicant) => {
+    getOrCreateDirectChatRoom(roomNo, applicant.userNo)
+      .then((chatRoomNo) => navigate('/chat/dm/' + chatRoomNo))
+      .catch((e) => alert(e?.message || '채팅방을 열 수 없어요.'));
+  };
+
+  if (loading) {
+    return (
+      <div className="screen">
+        <StatusBar />
+        <div style={{ padding: '6px 12px 8px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <button onClick={() => goBack(navigate, '/rooms/me')} style={{ background: 'transparent', border: 0, padding: 8, color: 'var(--ink)', cursor: 'pointer' }}><Icon.back /></button>
+          <div style={{ fontSize: 15, fontWeight: 600 }}>신청자 관리</div>
+          <div style={{ width: 38 }} />
+        </div>
+        <div style={{ padding: 32, textAlign: 'center', color: 'var(--ink-3)', fontSize: 14 }}>불러오는 중...</div>
+      </div>
+    );
+  }
 
   return (
     <div className="screen">
@@ -48,152 +83,125 @@ export function ApplicantsListScreen() {
       </div>
 
       <div className="scroll" style={{ padding: '0 16px 24px' }}>
-        {/* Header */}
         <div style={{ padding: '4px 4px 14px' }}>
           <div style={{ fontSize: 22, fontWeight: 700, letterSpacing: '-0.4px' }}>
-            신청자 <span style={{ color: 'var(--brand)' }}>{filteredApplicants.length}</span>명
+            신청자 <span style={{ color: 'var(--brand)' }}>{applicants.length}</span>명
           </div>
-          <div style={{ fontSize: 13, color: 'var(--ink-3)', marginTop: 4 }}>
-            {filter === '전체' ? '매칭이 잘 맞는 순서로 정렬했어요' : `${filter} 신청자만 보고 있어요`}
-          </div>
+          <div style={{ fontSize: 13, color: 'var(--ink-3)', marginTop: 4 }}>신청 순서로 정렬했어요</div>
         </div>
 
-        {/* Filter row */}
-        <div style={{ display: 'flex', gap: 6, marginBottom: 12, overflowX: 'auto' }}>
-	          {filterOptions.map((f) => {
-	            const active = filter === f;
-	            const count = f === '전체' ? applicants.length : applicants.filter((a) => a.match === f).length;
-	            return (
-              <button
-                key={f}
-                type="button"
-                onClick={() => setFilter(f)}
-                className={"chip " + (active ? 'ink' : 'line')}
-                style={{
-                  fontSize: 13,
-                  padding: '7px 12px',
-                  whiteSpace: 'nowrap',
-                  border: active ? 0 : '1px solid var(--line-2)',
-                  cursor: 'pointer',
-                  fontFamily: 'inherit',
-                }}
-              >
-                {f} {count}
-              </button>
-            );
-          })}
-        </div>
+        {error && (
+          <div style={{ padding: 16, textAlign: 'center', color: 'var(--ink-3)', fontSize: 14 }}>{error}</div>
+        )}
 
-        {/* List */}
-        {filteredApplicants.map((a) =>
-        <div key={a.id} onClick={() => navigate(`/room/applicants/${a.id}`)} className="card" style={{ padding: 14, marginBottom: 8, cursor: 'pointer' }}>
+        {!error && applicants.length === 0 && (
+          <div style={{ padding: 32, textAlign: 'center', color: 'var(--ink-3)', fontSize: 14 }}>아직 신청자가 없어요</div>
+        )}
+
+        {applicants.map((a) => (
+          <div
+            key={a.requestNo}
+            onClick={() => navigate(`/rooms/applicants/${a.requestNo}`, { state: { applicant: a, roomNo } })}
+            className="card"
+            style={{ padding: 14, marginBottom: 8, cursor: 'pointer' }}
+          >
             <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
-              <Avatar name={a.name} tone={a.tone} size={44} style={{ fontSize: 17 }} />
+              <Avatar name={a.nickname || a.name} size={44} style={{ fontSize: 17 }} />
               <div style={{ flex: 1, minWidth: 0 }}>
                 <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6 }}>
                   <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                    <span style={{ fontSize: 15, fontWeight: 700 }}>{a.name}</span>
-                    <span style={{ fontSize: 12, color: 'var(--ink-3)' }}>· {a.dept}</span>
+                    <span style={{ fontSize: 15, fontWeight: 700 }}>{a.nickname || a.name}</span>
+                    {a.major && <span style={{ fontSize: 12, color: 'var(--ink-3)' }}>· {a.major}</span>}
                   </div>
-                  <span style={{ fontSize: 11, color: 'var(--ink-3)' }}>{a.time}</span>
+                  <span style={{ fontSize: 11, color: 'var(--ink-3)' }}>{a.createdAt ? new Date(a.createdAt).toLocaleDateString('ko-KR', { month: 'numeric', day: 'numeric' }) : ''}</span>
                 </div>
-                <div style={{ marginTop: 4, display: 'flex', alignItems: 'center', gap: 8 }}>
-                  <span style={{
-                  fontSize: 11, fontWeight: 700,
-                  color: a.match === '잘 맞아요' ? 'var(--brand-deep)' : 'var(--ink-3)'
-                }}>{a.match === '잘 맞아요' ? '✓ ' : ''}{a.match}</span>
-                </div>
-                <div style={{ fontSize: 13, color: 'var(--ink-2)', lineHeight: 1.5, marginTop: 8 }}>
-                  <ClipText>"{a.message}"</ClipText>
-                </div>
+                {a.additionalMessage && (
+                  <div style={{ fontSize: 13, color: 'var(--ink-2)', lineHeight: 1.5, marginTop: 8 }}>
+                    <ClipText>"{a.additionalMessage}"</ClipText>
+                  </div>
+                )}
               </div>
             </div>
             <div style={{ display: 'flex', gap: 6, marginTop: 12, paddingTop: 12, borderTop: '1px solid var(--line)' }}>
-	              <button onClick={(e) => { e.stopPropagation(); requestDecision(a, 'reject'); }} style={{ flex: 1, height: 38, borderRadius: 10, border: 0, background: 'var(--surface-2)', color: 'var(--ink-2)', fontSize: 13, fontWeight: 600, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 4, cursor: 'pointer' }}>
+              <button
+                onClick={(e) => { e.stopPropagation(); requestDecision(a, 'reject'); }}
+                style={{ flex: 1, height: 38, borderRadius: 10, border: 0, background: 'var(--surface-2)', color: 'var(--ink-2)', fontSize: 13, fontWeight: 600, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 4, cursor: 'pointer' }}
+              >
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" /></svg>
                 거절
               </button>
-              <button onClick={(e) => { e.stopPropagation(); navigate('/chat/dm'); }} style={{ flex: 1, height: 38, borderRadius: 10, border: 0, background: 'var(--surface-2)', color: 'var(--ink-2)', fontSize: 13, fontWeight: 600, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 4, cursor: 'pointer' }}>
+              <button
+                onClick={(e) => { e.stopPropagation(); openDM(a); }}
+                style={{ flex: 1, height: 38, borderRadius: 10, border: 0, background: 'var(--surface-2)', color: 'var(--ink-2)', fontSize: 13, fontWeight: 600, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 4, cursor: 'pointer' }}
+              >
                 <Icon.chat size={14} /> 채팅
               </button>
-	              <button onClick={(e) => { e.stopPropagation(); requestDecision(a, 'accept'); }} style={{ flex: 1.4, height: 38, borderRadius: 10, border: 0, background: 'var(--brand)', color: 'white', fontSize: 13, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 4, cursor: 'pointer' }}>
+              <button
+                onClick={(e) => { e.stopPropagation(); requestDecision(a, 'accept'); }}
+                style={{ flex: 1.4, height: 38, borderRadius: 10, border: 0, background: 'var(--brand)', color: 'white', fontSize: 13, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 4, cursor: 'pointer' }}
+              >
                 <Icon.check size={14} weight={2.8} /> 수락
               </button>
             </div>
           </div>
-	        )}
-	      </div>
-	      {confirmAction && (
-	        <div onClick={() => setConfirmAction(null)} style={{ position: 'absolute', inset: 0, zIndex: 20, background: 'rgba(23,24,28,0.28)', display: 'flex', alignItems: 'flex-end' }}>
-	          <div onClick={(e) => e.stopPropagation()} style={{ width: '100%', background: 'var(--surface)', borderRadius: '22px 22px 0 0', padding: '10px 16px 30px', boxShadow: '0 -16px 40px rgba(23,24,28,0.14)' }}>
-	            <div style={{ width: 38, height: 4, borderRadius: 99, background: 'var(--line-2)', margin: '0 auto 14px' }} />
-	            <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '0 2px 18px' }}>
-	              <Avatar name={confirmAction.applicant.name} tone={confirmAction.applicant.tone} size={44} />
-	              <div style={{ flex: 1, minWidth: 0 }}>
-	                <div style={{ fontSize: 18, fontWeight: 700, letterSpacing: '-0.3px' }}>
-	                  {confirmAction.action === 'accept' ? '신청을 수락할까요?' : '신청을 거절할까요?'}
-	                </div>
-	                <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 4 }}>
-	                  {confirmAction.applicant.name} · {confirmAction.applicant.dept}
-	                </div>
-	              </div>
-	            </div>
-	            <div style={{ borderRadius: 14, background: 'var(--surface-2)', padding: 14, fontSize: 12, lineHeight: 1.5, color: 'var(--ink-2)', marginBottom: 12 }}>
-	              {confirmAction.action === 'accept'
-	                ? '수락하면 신청자는 방 멤버로 이동하고, 신청자 목록에서는 사라져요.'
-	                : '거절하면 신청자 목록에서 사라져요. 다시 되돌릴 수 없어요.'}
-	            </div>
-	            <div style={{ display: 'flex', gap: 8 }}>
-	              <button type="button" onClick={() => setConfirmAction(null)} className="btn ghost" style={{ width: 92, height: 52 }}>취소</button>
-	              <button
-	                type="button"
-	                onClick={completeDecision}
-	                className="btn full"
-	                style={{ flex: 1, height: 52, background: confirmAction.action === 'accept' ? 'var(--brand)' : 'var(--danger)' }}
-	              >
-	                {confirmAction.action === 'accept' ? '수락하기' : '거절하기'}
-	              </button>
-	            </div>
-	          </div>
-	        </div>
-	      )}
-	    </div>);
+        ))}
+      </div>
 
+      {confirmAction && (
+        <div onClick={() => setConfirmAction(null)} style={{ position: 'absolute', inset: 0, zIndex: 20, background: 'rgba(23,24,28,0.28)', display: 'flex', alignItems: 'flex-end' }}>
+          <div onClick={(e) => e.stopPropagation()} style={{ width: '100%', background: 'var(--surface)', borderRadius: '22px 22px 0 0', padding: '10px 16px 30px', boxShadow: '0 -16px 40px rgba(23,24,28,0.14)' }}>
+            <div style={{ width: 38, height: 4, borderRadius: 99, background: 'var(--line-2)', margin: '0 auto 14px' }} />
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '0 2px 18px' }}>
+              <Avatar name={confirmAction.applicant.nickname || confirmAction.applicant.name} size={44} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 18, fontWeight: 700, letterSpacing: '-0.3px' }}>
+                  {confirmAction.action === 'accept' ? '신청을 수락할까요?' : '신청을 거절할까요?'}
+                </div>
+                <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 4 }}>
+                  {confirmAction.applicant.nickname || confirmAction.applicant.name}{confirmAction.applicant.major ? ' · ' + confirmAction.applicant.major : ''}
+                </div>
+              </div>
+            </div>
+            <div style={{ borderRadius: 14, background: 'var(--surface-2)', padding: 14, fontSize: 12, lineHeight: 1.5, color: 'var(--ink-2)', marginBottom: 12 }}>
+              {confirmAction.action === 'accept'
+                ? '수락하면 신청자는 방 멤버로 이동하고, 신청자 목록에서는 사라져요.'
+                : '거절하면 신청자 목록에서 사라져요. 다시 되돌릴 수 없어요.'}
+            </div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button type="button" onClick={() => setConfirmAction(null)} className="btn ghost" style={{ width: 92, height: 52 }}>취소</button>
+              <button
+                type="button"
+                onClick={completeDecision}
+                className="btn full"
+                style={{ flex: 1, height: 52, background: confirmAction.action === 'accept' ? 'var(--brand)' : 'var(--danger)' }}
+              >
+                {confirmAction.action === 'accept' ? '수락하기' : '거절하기'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }
-
-// ─── 방 체크리스트 보기 (read-only) ──────────────────────────
-export const ROOM_VIEW_CHECKLIST = [
-{ cat: '생활 패턴', items: [
-  { q: '취침', a: '23시 – 01시' },
-  { q: '기상', a: '07시 – 09시' },
-  { q: '귀가', a: '고정적' },
-  { q: '청소', a: '주기적' },
-  { q: '방에서 전화', a: '가능' },
-  { q: '잠귀', a: '어두움' },
-  { q: '잠버릇', a: '약함' },
-  { q: '코골이', a: '약함~없음' },
-  { q: '샤워시간', a: '저녁' },
-  { q: '방에서 취식', a: '가능+환기필수' },
-  { q: '소등', a: '23시 이후' },
-  { q: '본가 주기', a: '2주' },
-  { q: '흡연', a: '비흡연' },
-  { q: '냉장고', a: '협의 후 결정' }]
-},
-{ cat: '추가 규칙', items: [
-  { q: '드라이기 제한', a: '12–19시 사용 제한' },
-  { q: '알람', a: '진동' },
-  { q: '이어폰', a: '항상' },
-  { q: '키스킨', a: '유동적' },
-  { q: '무소음 마우스', a: '사용' },
-  { q: '더위', a: '중간' },
-  { q: '추위', a: '중간' },
-  { q: '공부', a: '유동적' },
-  { q: '쓰레기통', a: '개별' }]
-}];
-
 
 export function RoomChecklistScreen() {
   const navigate = useNavigate();
+  const [checklist, setChecklist] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState('');
+
+  React.useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    setError('');
+    loadMyRoom()
+      .then((room) => loadMyRoomRule(room.roomNo))
+      .then((rule) => { if (mounted) setChecklist(roomRuleToChecklist(rule)); })
+      .catch(() => { if (mounted) setError('방 체크리스트를 불러오지 못했어요.'); })
+      .finally(() => { if (mounted) setLoading(false); });
+    return () => { mounted = false; };
+  }, []);
 
   return (
     <div className="screen">
@@ -213,11 +221,8 @@ export function RoomChecklistScreen() {
           </div>
         </div>
 
-        {/* Stats */}
         <div className="card" style={{ display: 'flex', gap: 4, padding: 4, marginBottom: 16 }}>
-          {[
-          { l: '생활 패턴', v: '14 / 14', sub: '필수' },
-          { l: '추가 규칙', v: '9 / 9', sub: '선택' }].
+          {checklist.map((section, index) => ({ l: section.cat, v: `${section.items.filter((item) => item.a !== '-').length} / ${section.items.length}`, sub: index === 0 ? '필수' : '선택' })).
           map((s, i, a) =>
           <div key={i} style={{ flex: 1, textAlign: 'center', padding: '10px 0', borderRight: i === a.length - 1 ? 'none' : '1px solid var(--line)' }}>
               <div style={{ fontSize: 11, color: 'var(--ink-3)', fontWeight: 600 }}>{s.l} <span style={{ color: s.sub === '필수' ? 'var(--brand)' : 'var(--ink-4)' }}>· {s.sub}</span></div>
@@ -226,8 +231,13 @@ export function RoomChecklistScreen() {
           )}
         </div>
 
-        {/* Checklist sections */}
-        {ROOM_VIEW_CHECKLIST.map((cat, ci) =>
+        {loading && (
+          <div style={{ padding: 24, textAlign: 'center', color: 'var(--ink-3)', fontSize: 13 }}>불러오는 중...</div>
+        )}
+        {error && (
+          <div style={{ padding: 24, textAlign: 'center', color: 'var(--danger)', fontSize: 13 }}>{error}</div>
+        )}
+        {!loading && !error && checklist.map((cat, ci) =>
         <div key={ci} style={{ marginBottom: 16 }}>
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px 10px' }}>
               <span style={{ fontSize: 14, fontWeight: 700, letterSpacing: '-0.2px' }}>{cat.cat}</span>
@@ -257,6 +267,33 @@ export function RoomChecklistScreen() {
 // Same form as CreateRoomScreen step 1 but without step indicator + with "저장" CTA
 export function EditPostScreen() {
   const navigate = useNavigate();
+  const [room, setRoom] = React.useState(null);
+  const [title, setTitle] = React.useState('');
+  const [notes, setNotes] = React.useState('');
+  const [saving, setSaving] = React.useState(false);
+
+  React.useEffect(() => {
+    let mounted = true;
+    loadMyRoom()
+      .then((data) => {
+        if (!mounted) return;
+        const normalized = normalizeRoom(data);
+        setRoom({ ...normalized, raw: data });
+        setTitle(data.title || '');
+        setNotes(data.notes || '');
+      })
+      .catch(() => alert('모집글 정보를 불러오지 못했어요.'));
+    return () => { mounted = false; };
+  }, []);
+
+  const save = () => {
+    if (!room || saving) return;
+    setSaving(true);
+    updateRoomTitle(room.roomNo, { title, notes })
+      .then(() => navigate('/rooms/me'))
+      .catch((e) => alert(e?.message || '저장하지 못했어요.'))
+      .finally(() => setSaving(false));
+  };
 
   return (
     <div className="screen">
@@ -264,21 +301,21 @@ export function EditPostScreen() {
       <div style={{ padding: '6px 12px 8px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <button onClick={() => goBack(navigate, '/rooms/me')} style={{ background: 'transparent', border: 0, padding: 8, color: 'var(--ink)', cursor: 'pointer' }}><Icon.back /></button>
         <div style={{ fontSize: 15, fontWeight: 600 }}>모집글 수정</div>
-        <button onClick={() => navigate('/rooms/me')} style={{ background: 'transparent', border: 0, padding: '6px 10px', color: 'var(--brand)', fontSize: 13, fontWeight: 700, cursor: 'pointer' }}>저장</button>
+        <button onClick={save} disabled={!room || saving || !title.trim()} style={{ background: 'transparent', border: 0, padding: '6px 10px', color: 'var(--brand)', fontSize: 13, fontWeight: 700, cursor: !room || saving || !title.trim() ? 'not-allowed' : 'pointer', opacity: !room || saving || !title.trim() ? 0.45 : 1 }}>{saving ? '저장 중' : '저장'}</button>
       </div>
 
       <div className="scroll" style={{ padding: '8px 20px 0' }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 14, paddingTop: 4 }}>
           <div>
             <label style={{ display: 'block', fontSize: 13, color: 'var(--ink-3)', marginBottom: 6, fontWeight: 600 }}>모집글 제목</label>
-            <input type="text" defaultValue="아침형 룸메 구해요" maxLength={30} style={{ width: '100%', background: 'var(--surface)', border: '1.5px solid var(--brand)', borderRadius: 14, padding: '14px 16px', fontSize: 15, outline: 0, fontFamily: 'inherit', color: 'var(--ink)', fontWeight: 500, boxSizing: 'border-box' }} />
-            <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 4, textAlign: 'right' }}>12 / 30</div>
+            <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} maxLength={30} style={{ width: '100%', background: 'var(--surface)', border: '1.5px solid var(--brand)', borderRadius: 14, padding: '14px 16px', fontSize: 15, outline: 0, fontFamily: 'inherit', color: 'var(--ink)', fontWeight: 500, boxSizing: 'border-box' }} />
+            <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 4, textAlign: 'right' }}>{title.length} / 30</div>
           </div>
 
           <div>
             <label style={{ display: 'block', fontSize: 13, color: 'var(--ink-3)', marginBottom: 6, fontWeight: 600 }}>기숙사</label>
             <div style={{ background: 'var(--surface-2)', borderRadius: 12, padding: '14px 16px', fontSize: 15, fontWeight: 600, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-              <span>2생활관 · 4인실</span>
+              <span>{room ? [room.dorm, room.size].filter(Boolean).join(' · ') : '불러오는 중'}</span>
               <span style={{ fontSize: 11, color: 'var(--ink-3)', fontWeight: 600 }}>변경 불가</span>
             </div>
             <div style={{ fontSize: 11, color: 'var(--ink-3)', marginTop: 4 }}>기숙사·인실은 모집방 생성 이후 변경할 수 없어요</div>
@@ -286,8 +323,8 @@ export function EditPostScreen() {
 
           <div>
             <label style={{ display: 'block', fontSize: 13, color: 'var(--ink-3)', marginBottom: 6, fontWeight: 600 }}>방장의 한마디</label>
-            <textarea defaultValue="아침 7시쯤 일어나는 사람이면 정말 좋아요. 청소는 일주일에 두 번 같이 하면 좋겠고, 평일 저녁엔 각자 시간 갖는 편이에요." maxLength={200} style={{ width: '100%', background: 'var(--surface-2)', borderRadius: 12, padding: 14, fontSize: 14, color: 'var(--ink-2)', minHeight: 100, lineHeight: 1.55, border: 0, outline: 0, fontFamily: 'inherit', resize: 'none', boxSizing: 'border-box' }} />
-            <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 4, textAlign: 'right' }}>82 / 200</div>
+            <textarea value={notes} onChange={(e) => setNotes(e.target.value)} maxLength={200} style={{ width: '100%', background: 'var(--surface-2)', borderRadius: 12, padding: 14, fontSize: 14, color: 'var(--ink-2)', minHeight: 100, lineHeight: 1.55, border: 0, outline: 0, fontFamily: 'inherit', resize: 'none', boxSizing: 'border-box' }} />
+            <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 4, textAlign: 'right' }}>{notes.length} / 200</div>
           </div>
 
 	        </div>

--- a/src/features/rooms/index.js
+++ b/src/features/rooms/index.js
@@ -9,11 +9,9 @@ export {
   ROOM_CHECKLIST_3,
   ROOM_CHECKLIST_4,
   CHECKLIST,
-  MY_ROOM_RECRUITING_KEY,
   residencePeriodLabel,
 } from './pages/Rooms.jsx';
 export {
   RecommendedRoomsScreen,
   RecommendedRoomCard,
 } from './pages/Recommended.jsx';
-

--- a/src/features/rooms/pages/Rooms.jsx
+++ b/src/features/rooms/pages/Rooms.jsx
@@ -4,9 +4,9 @@ import { Icon, TabBar, StatusBar, Avatar, MarqueeText, ClipText, goBack } from '
 import { MemberCard } from '../../members';
 import { CREATE_ROOM_DORMS, ROOM_SIZE_OPTIONS } from '../../checklist';
 import { findRooms, likeRoom, unlikeRoom, loadLikedRooms, loadMyChecklist, loadRoomRule, loadRecommendedRooms, loadMyRoom } from '../../../shared/api/home';
-import { getOrCreateDirectChatRoom, loadMyChatRooms } from '../../../shared/api/chat';
+import { getOrCreateDirectChatRoom, loadMyChatRooms, leaveChatRoom } from '../../../shared/api/chat';
 import { getCachedUserNo } from '../../../shared/api/auth';
-import { loadApplications, loadMyRoommates } from '../../../shared/api/room';
+import { loadApplications, loadMyRoommates, deleteRoom } from '../../../shared/api/room';
 import { normalizeRoom as normalizeBackendRoom, roommateToMember } from '../roomData';
 
 // rooms.jsx — 방 찾기 (list), 방 상세 (detail w/ checklist), 내 방 (my room)
@@ -858,14 +858,17 @@ export function RoomDetailScreen() {
   const [checklist, setChecklist] = React.useState([]);
   const [checklistLoading, setChecklistLoading] = React.useState(true);
   const [checklistError, setChecklistError] = React.useState(false);
+  const [isMyRoom, setIsMyRoom] = React.useState(false);
 
   React.useEffect(() => {
     let mounted = true;
     setChecklistLoading(true);
     setChecklistError(false);
-    Promise.all([loadRoomRule(id), loadMyChecklist()])
-      .then(([roomRule, myChecklist]) => {
-        if (mounted) setChecklist(compareChecklists(roomRule, myChecklist));
+    Promise.all([loadRoomRule(id), loadMyChecklist(), loadMyRoom().catch(() => null)])
+      .then(([roomRule, myChecklist, myRoom]) => {
+        if (!mounted) return;
+        setChecklist(compareChecklists(roomRule, myChecklist));
+        setIsMyRoom(myRoom?.roomNo === id);
       })
       .catch(() => {
         if (mounted) setChecklistError(true);
@@ -1062,7 +1065,9 @@ export function RoomDetailScreen() {
         >
           <Icon.chat size={22}/>
         </button>
-        {isClosed ? (
+        {isMyRoom ? (
+          <button disabled className="btn full" style={{ flex: 1, height: 52, background: 'var(--surface-2)', color: 'var(--ink-4)', cursor: 'not-allowed' }}>내가 만든 방</button>
+        ) : isClosed ? (
           <button disabled className="btn full" style={{ flex: 1, height: 52, background: 'var(--surface-2)', color: 'var(--ink-4)', cursor: 'not-allowed' }}>마감됨</button>
         ) : isApplied ? (
           <button disabled className="btn full" style={{ flex: 1, height: 52, background: 'var(--surface-2)', color: 'var(--ink-4)', cursor: 'not-allowed' }}>대기 중</button>
@@ -1085,6 +1090,7 @@ export function MyRoomScreen({ activeTab='myroom' }) {
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState('');
   const [groupChatRoomNo, setGroupChatRoomNo] = React.useState(null);
+  const [leaving, setLeaving] = React.useState(false);
 
   React.useEffect(() => {
     let mounted = true;
@@ -1145,9 +1151,18 @@ export function MyRoomScreen({ activeTab='myroom' }) {
   const isRoomFull = currentMembers >= roomCapacity;
 
   const leaveRoom = () => {
-    if (!canLeaveRoom) return;
+    if (!canLeaveRoom || leaving) return;
+    setLeaving(true);
     setMenuOpen(false);
-    navigate('/rooms/find');
+    const call = isHost
+      ? deleteRoom(room.roomNo)
+      : leaveChatRoom(groupChatRoomNo);
+    call
+      .then(() => navigate('/rooms/find'))
+      .catch((e) => {
+        alert(e?.message || '방 나가기에 실패했어요.');
+        setLeaving(false);
+      });
   };
 
 	  return (

--- a/src/features/rooms/pages/Rooms.jsx
+++ b/src/features/rooms/pages/Rooms.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { Icon, TabBar, StatusBar, Avatar, MarqueeText, ClipText, goBack } from '../../../shared/components';
-import { MemberCard, MEMBER_CHECKLISTS } from '../../members';
+import { MemberCard } from '../../members';
 import { CREATE_ROOM_DORMS, ROOM_SIZE_OPTIONS } from '../../checklist';
-import { findRooms, likeRoom, unlikeRoom, loadLikedRooms, loadMyChecklist, loadRoomRule, loadRecommendedRooms } from '../../../shared/api/home';
+import { findRooms, likeRoom, unlikeRoom, loadLikedRooms, loadMyChecklist, loadRoomRule, loadRecommendedRooms, loadMyRoom } from '../../../shared/api/home';
+import { getOrCreateDirectChatRoom, loadMyChatRooms } from '../../../shared/api/chat';
+import { getCachedUserNo } from '../../../shared/api/auth';
+import { loadApplications, loadMyRoommates } from '../../../shared/api/room';
+import { normalizeRoom as normalizeBackendRoom, roommateToMember } from '../roomData';
 
 // rooms.jsx — 방 찾기 (list), 방 상세 (detail w/ checklist), 내 방 (my room)
 
-export const MY_ROOM_RECRUITING_KEY = 'dorumdorum:my-room-recruiting';
 const ROOM_BOOKMARKS_KEY = 'dorumdorum:room-bookmarks';
 const ROOM_DETAIL_CACHE_KEY = 'dorumdorum:room-detail';
 
@@ -1046,7 +1049,17 @@ export function RoomDetailScreen() {
       {/* Sticky CTA */}
       {!isAccepted && (
       <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, padding: '14px 16px 30px', background: 'linear-gradient(180deg, transparent 0%, var(--bg) 30%)', display: 'flex', gap: 8 }}>
-        <button onClick={() => navigate('/chat/dm')} className="btn ghost" style={{ width: 52, height: 52, borderRadius: 14, padding: 0 }}>
+        <button
+          onClick={() => {
+            const myNo = getCachedUserNo();
+            if (!myNo) { navigate('/login'); return; }
+            getOrCreateDirectChatRoom(id, myNo)
+              .then((chatRoomNo) => navigate('/chat/dm/' + chatRoomNo))
+              .catch((e) => alert(e?.message || '채팅방을 열 수 없어요.'));
+          }}
+          className="btn ghost"
+          style={{ width: 52, height: 52, borderRadius: 14, padding: 0 }}
+        >
           <Icon.chat size={22}/>
         </button>
         {isClosed ? (
@@ -1066,53 +1079,75 @@ export function RoomDetailScreen() {
 export function MyRoomScreen({ activeTab='myroom' }) {
   const navigate = useNavigate();
   const [menuOpen, setMenuOpen] = React.useState(false);
-  const [isRecruiting, setIsRecruiting] = React.useState(() => {
-    if (typeof window === 'undefined') return true;
-    return window.sessionStorage.getItem(MY_ROOM_RECRUITING_KEY) !== 'false';
-  });
-  const [rules, setRules] = React.useState([
-    '소등은 23:00, 조명은 무드등만 사용',
-    '청소 당번 — 매주 일요일 저녁',
-    '외부인 방문 시 단톡방에 미리 공유',
-    '간식은 함께 나눠 먹기',
-  ]);
-  const [rulesEditing, setRulesEditing] = React.useState(false);
-  const [ruleDraft, setRuleDraft] = React.useState('');
-  const isHost = true;
-  const currentMembers = 2;
-  const roomCapacity = 4;
+  const [room, setRoom] = React.useState(null);
+  const [members, setMembers] = React.useState([]);
+  const [applicantCount, setApplicantCount] = React.useState(0);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState('');
+  const [groupChatRoomNo, setGroupChatRoomNo] = React.useState(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    setError('');
+    Promise.all([
+      loadMyRoom(),
+      loadMyRoommates().catch(() => []),
+      loadMyChatRooms().catch(() => []),
+    ])
+      .then(([roomData, roommateList, chatRooms]) => {
+        if (!mounted) return;
+        if (!roomData?.roomNo) {
+          setRoom(null);
+          setMembers([]);
+          setApplicantCount(0);
+          setGroupChatRoomNo(null);
+          return;
+        }
+        const normalized = normalizeBackendRoom(roomData);
+        const mappedMembers = Array.isArray(roommateList) ? roommateList.map(roommateToMember) : [];
+        const myMember = mappedMembers.find((member) => member.isMe);
+        setRoom(normalized);
+        setMembers(mappedMembers);
+        const chatList = Array.isArray(chatRooms) ? chatRooms : chatRooms?.items || [];
+        const found = chatList.find(
+          (chatRoom) => chatRoom.chatRoomType === 'GROUP' && String(chatRoom.roomNo) === String(roomData.roomNo),
+        );
+        setGroupChatRoomNo(found?.chatRoomNo || null);
+        if (myMember?.role === '방장') {
+          return loadApplications(roomData.roomNo)
+            .then((applications) => { if (mounted) setApplicantCount(Array.isArray(applications) ? applications.length : 0); })
+            .catch(() => { if (mounted) setApplicantCount(0); });
+        }
+        setApplicantCount(0);
+      })
+      .catch((e) => {
+        if (!mounted) return;
+        if (e?.status === 404 || e?.code === 'ROOM003') {
+          setRoom(null);
+          setMembers([]);
+          setApplicantCount(0);
+          setGroupChatRoomNo(null);
+          return;
+        }
+        setError('내 방 정보를 불러오지 못했어요.');
+      })
+      .finally(() => { if (mounted) setLoading(false); });
+    return () => { mounted = false; };
+  }, []);
+
+  const isHost = members.find((member) => member.isMe)?.role === '방장';
+  const currentMembers = room?.members ?? members.length;
+  const roomCapacity = room?.capacity ?? 0;
+  const isRecruiting = room?.recruiting ?? false;
   const canLeaveRoom = !isHost || currentMembers <= 1;
   const openSeats = Math.max(0, roomCapacity - currentMembers);
   const isRoomFull = currentMembers >= roomCapacity;
-  const canCloseRecruiting = !isRecruiting || isRoomFull;
-
-  React.useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.sessionStorage.setItem(MY_ROOM_RECRUITING_KEY, String(isRecruiting));
-    }
-  }, [isRecruiting]);
 
   const leaveRoom = () => {
     if (!canLeaveRoom) return;
     setMenuOpen(false);
     navigate('/rooms/find');
-  };
-
-  const toggleRecruiting = () => {
-    if (isRecruiting && !isRoomFull) return;
-    setIsRecruiting((v) => !v);
-    setMenuOpen(false);
-  };
-
-  const addRule = () => {
-    const nextRule = ruleDraft.trim();
-    if (!nextRule) return;
-    setRules((items) => [...items, nextRule]);
-    setRuleDraft('');
-  };
-
-  const removeRule = (index) => {
-    setRules((items) => items.filter((_, itemIndex) => itemIndex !== index));
   };
 
 	  return (
@@ -1121,10 +1156,51 @@ export function MyRoomScreen({ activeTab='myroom' }) {
 	        <StatusBar />
 	        <div className="topbar">
 	          <div className="brand">내 방</div>
-	          <button onClick={() => setMenuOpen(true)} aria-label="방 관리 메뉴" style={{ background: 'transparent', border: 0, color: 'var(--ink)', padding: 6, display: 'flex', cursor: 'pointer' }}>
+	          <button onClick={() => room && setMenuOpen(true)} aria-label="방 관리 메뉴" style={{ background: 'transparent', border: 0, color: room ? 'var(--ink)' : 'var(--ink-4)', padding: 6, display: 'flex', cursor: room ? 'pointer' : 'default' }}>
 	            <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><circle cx="5" cy="12" r="1.8" fill="currentColor"/><circle cx="12" cy="12" r="1.8" fill="currentColor"/><circle cx="19" cy="12" r="1.8" fill="currentColor"/></svg>
 	          </button>
 	        </div>
+        {loading && (
+          <div style={{ padding: '24px 16px', color: 'var(--ink-3)', fontSize: 13 }}>내 방 정보를 불러오는 중...</div>
+        )}
+        {error && (
+          <div className="card" style={{ margin: '4px 16px 16px', padding: 18, color: 'var(--danger)', fontSize: 13 }}>{error}</div>
+        )}
+        {!loading && !error && !room && (
+          <div style={{ minHeight: 360, padding: '72px 24px 24px', display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center' }}>
+            <div style={{ width: 58, height: 58, borderRadius: 18, background: 'var(--surface-2)', color: 'var(--ink-4)', display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 16 }}>
+              <Icon.door size={28} weight={1.8} />
+            </div>
+            <div style={{ fontSize: 15, color: 'var(--ink-3)', fontWeight: 700 }}>아직 참여 중인 방이 없어요.</div>
+            <div style={{ fontSize: 13, color: 'var(--ink-3)', lineHeight: 1.5, marginTop: 6 }}>
+              모집방을 만들거나 방 찾기에서 입주 신청을 해보세요.
+            </div>
+            <button
+              onClick={() => navigate('/rooms/create/1')}
+              style={{
+                marginTop: 20,
+                height: 52,
+                padding: '0 18px',
+                borderRadius: 26,
+                border: 0,
+                background: 'var(--ink)',
+                color: 'white',
+                fontWeight: 700,
+                fontSize: 14,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+                boxShadow: '0 8px 24px rgba(0,0,0,0.14)',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+            >
+              <Icon.plus size={18} /> 모집방 만들기
+            </button>
+          </div>
+        )}
+        {!loading && !error && room && (
+        <>
 	        {/* Hero card */}
         <div style={{ padding: '4px 16px 16px' }}>
           <div style={{
@@ -1133,8 +1209,8 @@ export function MyRoomScreen({ activeTab='myroom' }) {
           }}>
             <div style={{ position: 'absolute', right: -40, top: -40, width: 160, height: 160, borderRadius: '50%', background: 'rgba(255,255,255,0.10)' }}/>
             <div style={{ position: 'absolute', right: -10, bottom: -30, width: 100, height: 100, borderRadius: '50%', background: 'rgba(255,255,255,0.06)' }}/>
-            <div style={{ fontSize: 30, fontWeight: 700, letterSpacing: '-1px' }}>아침형 룸메 구해요</div>
-            <div style={{ fontSize: 14, opacity: 0.9, marginTop: 2 }}>2생활관 · 4인실</div>
+            <div style={{ fontSize: 30, fontWeight: 700, letterSpacing: '-1px' }}>{room.title}</div>
+            <div style={{ fontSize: 14, opacity: 0.9, marginTop: 2 }}>{[room.dorm, room.size].filter(Boolean).join(' · ')}</div>
 
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 0, marginTop: 22, position: 'relative' }}>
               <div>
@@ -1152,9 +1228,9 @@ export function MyRoomScreen({ activeTab='myroom' }) {
         {/* Quick actions — pill list */}
         <div style={{ padding: '0 16px', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
           {[
-            { i: 'chat', l: '방 채팅', sub: '4명 참여', hasNew: true, to: '/chat/group' },
-            { i: 'user', l: '신청자 관리', sub: '5명 대기 중', hasNew: true, to: '/rooms/applicants' },
-            { i: 'clipboard', l: '방 체크리스트', sub: '11/12 작성됨', to: '/rooms/checklist' },
+            { i: 'chat', l: '방 채팅', sub: `${currentMembers}명 참여`, hasNew: false, to: groupChatRoomNo ? '/chat/group/' + groupChatRoomNo : '/chat' },
+            { i: 'user', l: '신청자 관리', sub: `${applicantCount}명 대기 중`, hasNew: applicantCount > 0, to: '/rooms/applicants' },
+            { i: 'clipboard', l: '방 체크리스트', sub: '방 기준 보기', to: '/rooms/checklist' },
             { i: 'edit', l: '모집글 수정', sub: '제목·소개 변경', to: '/rooms/edit' },
           ].map((a, i) => {
             const I = Icon[a.i];
@@ -1198,62 +1274,27 @@ export function MyRoomScreen({ activeTab='myroom' }) {
 	          </span>
 	        </div>
         <div style={{ margin: '0 16px' }}>
-          {MEMBER_CHECKLISTS.map((m, i) => (
-            <MemberCard key={i} m={m} defaultOpen={false}/>
-          ))}
+          {members.length > 0 ? members.map((m) => (
+            <MemberCard key={m.id} m={m} defaultOpen={false}/>
+          )) : (
+            <div className="card" style={{ padding: 18, color: 'var(--ink-3)', fontSize: 13 }}>룸메이트 정보를 불러올 수 없어요.</div>
+          )}
         </div>
 
-        {/* Room rules */}
+        {/* Room notes */}
         <div className="h-section">
-          <h2>우리 방 약속</h2>
-          <button
-            type="button"
-            onClick={() => setRulesEditing((editing) => !editing)}
-            className="more"
-            style={{ border: 0, background: 'transparent', padding: 0, fontFamily: 'inherit', cursor: 'pointer' }}
-          >
-            {rulesEditing ? '완료' : '수정'}
-          </button>
+          <h2>방장의 한마디</h2>
+          <span className="more" onClick={() => navigate('/rooms/edit')} style={{ cursor: 'pointer' }}>수정</span>
         </div>
-        {!rulesEditing ? (
-          <div style={{ margin: '0 16px 24px' }} className="card">
-            {rules.map((rule, i, list) => (
-              <div key={`${rule}-${i}`} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, padding: '10px 0', borderBottom: i === list.length - 1 ? 'none' : '1px solid var(--line)' }}>
-                <div style={{ width: 22, height: 22, borderRadius: 7, background: 'var(--brand-soft)', color: 'var(--brand-deep)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700, fontSize: 11, flexShrink: 0 }}>{i + 1}</div>
-                <div style={{ fontSize: 14, color: 'var(--ink)', lineHeight: 1.5 }}>{rule}</div>
-              </div>
-            ))}
+        <div style={{ margin: '0 16px 24px' }} className="card">
+          <div style={{ fontSize: 14, color: room.notes ? 'var(--ink)' : 'var(--ink-3)', lineHeight: 1.6 }}>
+            {room.notes || '아직 작성된 한마디가 없어요.'}
           </div>
-        ) : (
-	          <div style={{ margin: '0 16px 24px' }} className="card">
-            {rules.map((rule, i) => (
-              <div key={`${rule}-${i}`} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 0', borderBottom: '1px solid var(--line)' }}>
-                <div style={{ width: 22, height: 22, borderRadius: 7, background: 'var(--brand-soft)', color: 'var(--brand-deep)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700, fontSize: 11, flexShrink: 0 }}>{i + 1}</div>
-                <div style={{ flex: 1, minWidth: 0, fontSize: 14, color: 'var(--ink)', lineHeight: 1.5 }}>{rule}</div>
-                <button type="button" onClick={() => removeRule(i)} aria-label="약속 삭제" style={{ width: 20, height: 20, borderRadius: '50%', border: 0, background: 'var(--surface-2)', color: 'var(--ink-3)', fontSize: 12, lineHeight: 1, cursor: 'pointer', flexShrink: 0, padding: 0 }}>×</button>
-              </div>
-            ))}
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                addRule();
-              }}
-              style={{ display: 'flex', alignItems: 'center', gap: 8, paddingTop: 12 }}
-            >
-              <input
-                value={ruleDraft}
-                onChange={(e) => setRuleDraft(e.target.value)}
-                placeholder="새 약속 입력"
-                style={{ flex: 1, minWidth: 0, height: 42, border: 0, outline: 'none', borderRadius: 13, background: 'var(--surface-2)', padding: '0 12px', fontFamily: 'inherit', fontSize: 14, color: 'var(--ink)' }}
-              />
-              <button type="submit" disabled={!ruleDraft.trim()} style={{ height: 42, border: 0, borderRadius: 13, background: 'var(--brand)', color: 'white', padding: '0 13px', display: 'flex', alignItems: 'center', gap: 5, fontFamily: 'inherit', fontSize: 13, fontWeight: 700, opacity: ruleDraft.trim() ? 1 : 0.45, cursor: ruleDraft.trim() ? 'pointer' : 'not-allowed' }}>
-                <Icon.plus size={16} /> 추가
-              </button>
-            </form>
-          </div>
-        )}
+        </div>
 
         <div style={{ height: 24 }}/>
+        </>
+        )}
       </div>
 
       <TabBar active={activeTab}/>
@@ -1316,15 +1357,14 @@ export function MyRoomScreen({ activeTab='myroom' }) {
 
 		            <button
 		              type="button"
-		              onClick={toggleRecruiting}
-                  disabled={!canCloseRecruiting}
+		              disabled
 		              style={{
 		                width: '100%',
 		                minHeight: 52,
 		                border: 0,
 		                borderRadius: 14,
-		                background: !canCloseRecruiting ? 'var(--surface-2)' : isRecruiting ? 'rgba(245,166,35,0.12)' : 'var(--brand-soft)',
-		                color: !canCloseRecruiting ? 'var(--ink-4)' : isRecruiting ? '#9A6200' : 'var(--brand-deep)',
+		                background: 'var(--surface-2)',
+		                color: 'var(--ink-4)',
 		                display: 'flex',
 		                alignItems: 'center',
 		                justifyContent: 'space-between',
@@ -1332,19 +1372,13 @@ export function MyRoomScreen({ activeTab='myroom' }) {
 		                fontFamily: 'inherit',
 		                fontSize: 15,
 		                fontWeight: 700,
-		                cursor: canCloseRecruiting ? 'pointer' : 'not-allowed',
+		                cursor: 'not-allowed',
 		                marginBottom: 8,
 		              }}
 		            >
-		              <span>{isRecruiting ? '모집 마감하기' : '모집 다시 열기'}</span>
+		              <span>모집 상태</span>
 		              <span style={{ fontSize: 11, fontWeight: 700 }}>{isRecruiting ? (isRoomFull ? '정원 완료' : `${openSeats}자리 남음`) : '모집 완료'}</span>
 		            </button>
-
-                {isRecruiting && !isRoomFull && (
-                  <div style={{ margin: '-2px 0 8px', borderRadius: 12, background: 'var(--brand-soft)', color: 'var(--brand-deep)', padding: 12, fontSize: 12, lineHeight: 1.5, fontWeight: 600 }}>
-                    모든 인원이 다 찬 뒤에 모집을 마감할 수 있어요.
-                  </div>
-                )}
 
 	            <button
 	              type="button"

--- a/src/features/rooms/roomData.js
+++ b/src/features/rooms/roomData.js
@@ -1,0 +1,324 @@
+const ROOM_TYPE_LABELS = {
+  TYPE_1: '1생활관',
+  TYPE_2: '2생활관',
+  TYPE_3: '3생활관',
+  TYPE_MEDICAL: '메디컬',
+};
+
+const ROOM_TYPE_BY_LABEL = Object.fromEntries(
+  Object.entries(ROOM_TYPE_LABELS).map(([key, label]) => [label, key]),
+);
+
+export const roomTypeLabel = (roomType) => ROOM_TYPE_LABELS[roomType] || roomType || '';
+
+export const RESIDENCE_PERIOD_LABELS = {
+  SEMESTER: '학기(16주)',
+  HALF_YEAR: '반기(24주)',
+  SEASONAL: '계절학기',
+};
+
+export const residencePeriodLabel = (period) => RESIDENCE_PERIOD_LABELS[period] || period || '';
+
+export const CHECKLIST_VALUE_LABELS = {
+  FLEXIBLE: '유동적',
+  FIXED: '고정적',
+  REGULAR: '주기적',
+  IRREGULAR: '비주기적',
+  ALLOWED: '가능',
+  NOT_ALLOWED: '불가능',
+  ALLOWED_WITH_VENTILATION: '가능 · 환기 필수',
+  BRIGHT: '밝음',
+  DARK: '어두움',
+  SEVERE: '심함',
+  MODERATE: '중간',
+  MILD: '약함',
+  MILD_OR_NONE: '약함 · 없음',
+  MORNING: '아침',
+  EVENING: '저녁',
+  AFTER_TIME: '시간 지정',
+  WHEN_ONE_SLEEPS: '한 명이 잘 때',
+  WEEKLY: '매주',
+  BIWEEKLY: '2주',
+  MONTHLY_OR_MORE: '한 달 이상',
+  RARELY: '거의 안 감',
+  CIGARETTE: '흡연',
+  E_CIGARETTE: '전자담배',
+  NON_SMOKER: '비흡연',
+  RENT_PURCHASE_OWN: '대여 · 구매 · 보유',
+  DECIDE_AFTER_DISCUSSION: '협의 후 결정',
+  NOT_NEEDED: '필요 없음',
+  VIBRATION: '진동',
+  SOUND: '소리',
+  ALWAYS: '항상',
+  VERY_SENSITIVE: '많이 탐',
+  LESS_SENSITIVE: '적게 탐',
+  OUTSIDE_DORM: '기숙사 밖',
+  INSIDE_DORM: '기숙사 안',
+  INDIVIDUAL: '개별',
+  SHARED: '공유',
+};
+
+export const checklistValueLabel = (value) => CHECKLIST_VALUE_LABELS[value] || value || '-';
+
+export const CHECKLIST_SECTIONS = [
+  { cat: '생활 패턴', items: [
+    { key: 'bedtime', q: '취침' },
+    { key: 'wakeUp', q: '기상' },
+    { key: 'returnHome', q: '귀가' },
+    { key: 'returnHomeTime', q: '귀가 시간' },
+    { key: 'cleaning', q: '청소' },
+    { key: 'phoneCall', q: '방에서 전화' },
+    { key: 'sleepLight', q: '잠귀' },
+    { key: 'sleepHabit', q: '잠버릇' },
+    { key: 'snoring', q: '코골이' },
+    { key: 'showerTime', q: '샤워 시간' },
+    { key: 'eating', q: '방에서 취식' },
+    { key: 'lightsOut', q: '소등' },
+    { key: 'lightsOutTime', q: '소등 시간' },
+    { key: 'homeVisit', q: '본가 주기' },
+    { key: 'smoking', q: '흡연' },
+    { key: 'refrigerator', q: '냉장고' },
+  ] },
+  { cat: '추가 규칙', items: [
+    { key: 'hairDryer', q: '드라이기 제한' },
+    { key: 'alarm', q: '알람' },
+    { key: 'earphone', q: '이어폰' },
+    { key: 'keyskin', q: '키스킨' },
+    { key: 'heat', q: '더위' },
+    { key: 'cold', q: '추위' },
+    { key: 'study', q: '공부' },
+    { key: 'trashCan', q: '쓰레기통' },
+  ] },
+];
+
+export const normalizeRoom = (room) => ({
+  id: room.roomNo,
+  roomNo: room.roomNo,
+  title: room.title,
+  dorm: roomTypeLabel(room.roomType),
+  roomType: room.roomType,
+  size: `${room.capacity}인실`,
+  members: room.currentMateCount,
+  capacity: room.capacity,
+  remaining: room.remaining,
+  recruiting: room.roomStatus !== 'COMPLETED',
+  host: {
+    name: room.hostNickname,
+    major: room.hostMajor,
+    studentYear: room.hostStudentYear,
+  },
+  roomStatus: room.roomStatus,
+  residencePeriod: room.residencePeriod,
+  notes: room.notes ?? null,
+  checklist: [],
+});
+
+export const roomRuleToChecklist = (rule = {}) => CHECKLIST_SECTIONS.map((section) => ({
+  cat: section.cat,
+  items: section.items.map((item) => ({ q: item.q, a: checklistValueLabel(rule[item.key]) })),
+}));
+
+export const compareChecklists = (roomRule = {}, myChecklist = {}) => CHECKLIST_SECTIONS.map((section) => ({
+  cat: section.cat,
+  items: section.items.map((item) => ({
+    q: item.q,
+    room: checklistValueLabel(roomRule[item.key]),
+    mine: checklistValueLabel(myChecklist[item.key]),
+    match: roomRule[item.key] === myChecklist[item.key],
+  })),
+}));
+
+const LABEL_TO_ENUM = {
+  '유동적': 'FLEXIBLE',
+  '고정적': 'FIXED',
+  '주기적': 'REGULAR',
+  '비주기적': 'IRREGULAR',
+  '가능': 'ALLOWED',
+  '불가능': 'NOT_ALLOWED',
+  '가능+환기필수': 'ALLOWED_WITH_VENTILATION',
+  '가능 · 환기 필수': 'ALLOWED_WITH_VENTILATION',
+  '밝음': 'BRIGHT',
+  '어두움': 'DARK',
+  '심함': 'SEVERE',
+  '중간': 'MODERATE',
+  '약함': 'MILD',
+  '약함~없음': 'MILD_OR_NONE',
+  '약함 · 없음': 'MILD_OR_NONE',
+  '아침': 'MORNING',
+  '저녁': 'EVENING',
+  '시간 지정': 'AFTER_TIME',
+  '한명 잘 때 알아서': 'WHEN_ONE_SLEEPS',
+  '한 명이 잘 때': 'WHEN_ONE_SLEEPS',
+  '매주': 'WEEKLY',
+  '2주': 'BIWEEKLY',
+  '한달이상': 'MONTHLY_OR_MORE',
+  '한 달 이상': 'MONTHLY_OR_MORE',
+  '거의 안 감': 'RARELY',
+  '연초': 'CIGARETTE',
+  '흡연': 'CIGARETTE',
+  '전자담배': 'E_CIGARETTE',
+  '비흡연': 'NON_SMOKER',
+  '대여·구매·보유': 'RENT_PURCHASE_OWN',
+  '대여 · 구매 · 보유': 'RENT_PURCHASE_OWN',
+  '협의 후 결정': 'DECIDE_AFTER_DISCUSSION',
+  '필요 없음': 'NOT_NEEDED',
+  '진동': 'VIBRATION',
+  '소리': 'SOUND',
+  '항상': 'ALWAYS',
+  '많이 탐': 'VERY_SENSITIVE',
+  '적게 탐': 'LESS_SENSITIVE',
+  '기숙사 밖': 'OUTSIDE_DORM',
+  '기숙사 안': 'INSIDE_DORM',
+  '개별': 'INDIVIDUAL',
+  '공유': 'SHARED',
+};
+
+const enumToLabel = (value) => CHECKLIST_VALUE_LABELS[value] || value || null;
+const labelToEnum = (value) => LABEL_TO_ENUM[value] || value || null;
+
+const parseHour = (value, fallback) => {
+  const match = String(value || '').match(/\d{1,2}/);
+  if (!match) return fallback;
+  return Math.max(0, Math.min(23, Number(match[0])));
+};
+
+const parseRange = (value, fallback) => {
+  const timeMatches = String(value || '').match(/\d{1,2}:\d{2}/g);
+  if (timeMatches && timeMatches.length >= 2) {
+    return {
+      start: parseHour(timeMatches[0], fallback.start),
+      end: parseHour(timeMatches[1], fallback.end),
+    };
+  }
+  const matches = String(value || '').match(/\d{1,2}/g);
+  if (!matches || matches.length < 2) return fallback;
+  return {
+    start: Math.max(0, Math.min(23, Number(matches[0]))),
+    end: Math.max(0, Math.min(23, Number(matches[1]))),
+  };
+};
+
+const fmtHour = (hour) => `${String(hour).padStart(2, '0')}:00`;
+const fmtRange = (range) => `${fmtHour(range.start)}-${fmtHour(range.end)}`;
+
+export const defaultRoomChecklistForm = {
+  sleep: { start: 23, end: 1 },
+  wake: { start: 7, end: 9 },
+  dryer: null,
+  homing: '유동적',
+  cleaning: '주기적',
+  call: '가능',
+  dim: '어두움',
+  sleepHabit: '약함',
+  snore: '약함~없음',
+  shower: '저녁',
+  eating: '가능+환기필수',
+  lightsOut: '시간 지정',
+  lightsOutHour: 23,
+  visitHome: '2주',
+  smoke: '비흡연',
+  fridge: '협의 후 결정',
+  alarm: '진동',
+  earphone: '항상',
+  skinCare: '유동적',
+  silentMouse: '사용',
+  hot: '중간',
+  cold: '중간',
+  study: '유동적',
+  trash: '개별',
+};
+
+export function roomRuleToChecklistForm(rule = {}) {
+  return {
+    ...defaultRoomChecklistForm,
+    sleep: parseRange(rule.bedtime, defaultRoomChecklistForm.sleep),
+    wake: parseRange(rule.wakeUp, defaultRoomChecklistForm.wake),
+    dryer: rule.hairDryer ? parseRange(rule.hairDryer, { start: 12, end: 19 }) : null,
+    homing: enumToLabel(rule.returnHome) || defaultRoomChecklistForm.homing,
+    cleaning: enumToLabel(rule.cleaning) || defaultRoomChecklistForm.cleaning,
+    call: enumToLabel(rule.phoneCall) || defaultRoomChecklistForm.call,
+    dim: enumToLabel(rule.sleepLight) || defaultRoomChecklistForm.dim,
+    sleepHabit: enumToLabel(rule.sleepHabit) || defaultRoomChecklistForm.sleepHabit,
+    snore: enumToLabel(rule.snoring) || defaultRoomChecklistForm.snore,
+    shower: enumToLabel(rule.showerTime) || defaultRoomChecklistForm.shower,
+    eating: enumToLabel(rule.eating)?.replaceAll(' · ', '+') || defaultRoomChecklistForm.eating,
+    lightsOut: enumToLabel(rule.lightsOut) || defaultRoomChecklistForm.lightsOut,
+    lightsOutHour: parseHour(rule.lightsOutTime, defaultRoomChecklistForm.lightsOutHour),
+    visitHome: enumToLabel(rule.homeVisit) || defaultRoomChecklistForm.visitHome,
+    smoke: enumToLabel(rule.smoking) || defaultRoomChecklistForm.smoke,
+    fridge: enumToLabel(rule.refrigerator)?.replaceAll(' · ', '·') || defaultRoomChecklistForm.fridge,
+    alarm: enumToLabel(rule.alarm) || defaultRoomChecklistForm.alarm,
+    earphone: enumToLabel(rule.earphone) || defaultRoomChecklistForm.earphone,
+    skinCare: enumToLabel(rule.keyskin) || defaultRoomChecklistForm.skinCare,
+    hot: enumToLabel(rule.heat) || defaultRoomChecklistForm.hot,
+    cold: enumToLabel(rule.cold) || defaultRoomChecklistForm.cold,
+    study: enumToLabel(rule.study) || defaultRoomChecklistForm.study,
+    trash: enumToLabel(rule.trashCan) || defaultRoomChecklistForm.trash,
+  };
+}
+
+export function checklistFormToRoomRuleRequest(form, room) {
+  return {
+    bedtime: fmtRange(form.sleep),
+    wakeUp: fmtRange(form.wake),
+    returnHome: labelToEnum(form.homing),
+    returnHomeTime: fmtHour(23),
+    cleaning: labelToEnum(form.cleaning),
+    phoneCall: labelToEnum(form.call),
+    sleepLight: labelToEnum(form.dim),
+    sleepHabit: labelToEnum(form.sleepHabit),
+    snoring: labelToEnum(form.snore),
+    showerTime: labelToEnum(form.shower),
+    eating: labelToEnum(form.eating),
+    lightsOut: labelToEnum(form.lightsOut),
+    lightsOutTime: fmtHour(form.lightsOutHour),
+    homeVisit: labelToEnum(form.visitHome),
+    smoking: labelToEnum(form.smoke),
+    refrigerator: labelToEnum(form.fridge),
+    hairDryer: form.dryer ? fmtRange(form.dryer) : null,
+    alarm: labelToEnum(form.alarm),
+    earphone: labelToEnum(form.earphone),
+    keyskin: labelToEnum(form.skinCare),
+    heat: labelToEnum(form.hot),
+    cold: labelToEnum(form.cold),
+    study: labelToEnum(form.study),
+    trashCan: labelToEnum(form.trash),
+    otherNotes: null,
+    roomType: room.roomType,
+    capacity: room.capacity,
+    residencePeriod: room.residencePeriod,
+  };
+}
+
+export function createRoomDraftToRequest(draft, checklistForm = defaultRoomChecklistForm) {
+  const roomType = ROOM_TYPE_BY_LABEL[draft.dorm] || draft.roomType || 'TYPE_2';
+  const capacity = Number.parseInt(draft.roomSize || draft.capacity, 10) || 4;
+  const rule = checklistFormToRoomRuleRequest(checklistForm, {
+    roomType,
+    capacity,
+    residencePeriod: draft.residencePeriod || 'SEMESTER',
+  });
+  const { roomType: _roomType, capacity: _capacity, residencePeriod: _residencePeriod, ...ruleOnly } = rule;
+
+  return {
+    roomType,
+    capacity,
+    residencePeriod: draft.residencePeriod || 'SEMESTER',
+    title: draft.title,
+    notes: draft.notes || '',
+    rule: ruleOnly,
+  };
+}
+
+export const roommateToMember = (roommate) => ({
+  id: roommate.roommateNo || roommate.userNo,
+  userNo: roommate.userNo,
+  name: roommate.nickname || roommate.name,
+  realName: roommate.name,
+  studentId: roommate.studentNo,
+  dept: [roommate.major, roommate.grade ? `${roommate.grade}학년` : null].filter(Boolean).join(' '),
+  role: roommate.roomRole === 'HOST' ? '방장' : '멤버',
+  isMe: Boolean(roommate.isMe),
+  confirmStatus: roommate.confirmStatus,
+  checklist: [],
+});

--- a/src/features/rooms/roomData.test.js
+++ b/src/features/rooms/roomData.test.js
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checklistFormToRoomRuleRequest,
+  createRoomDraftToRequest,
+  normalizeRoom,
+  roomRuleToChecklist,
+  roomRuleToChecklistForm,
+} from './roomData';
+
+describe('roomData helpers', () => {
+  it('normalizeRoom은 백엔드 방 응답을 화면 모델로 변환한다', () => {
+    expect(normalizeRoom({
+      roomNo: 'room-1',
+      roomType: 'TYPE_2',
+      capacity: 4,
+      currentMateCount: 2,
+      remaining: 2,
+      title: '아침형 룸메 구해요',
+      notes: '조용히 지내요',
+      hostNickname: '민지',
+      hostMajor: '컴퓨터공학과',
+      hostStudentYear: '22',
+      roomStatus: 'CONFIRM_PENDING',
+      residencePeriod: 'SEMESTER',
+    })).toMatchObject({
+      id: 'room-1',
+      roomNo: 'room-1',
+      dorm: '2생활관',
+      size: '4인실',
+      members: 2,
+      capacity: 4,
+      recruiting: true,
+      host: { name: '민지', major: '컴퓨터공학과', studentYear: '22' },
+    });
+  });
+
+  it('roomRuleToChecklist는 enum과 시간 문자열을 표시용 섹션으로 변환한다', () => {
+    const sections = roomRuleToChecklist({
+      bedtime: '23:00',
+      wakeUp: '07:00',
+      returnHome: 'FIXED',
+      cleaning: 'REGULAR',
+      phoneCall: 'ALLOWED',
+      sleepLight: 'DARK',
+      sleepHabit: 'MILD',
+      snoring: 'MILD_OR_NONE',
+      showerTime: 'EVENING',
+      eating: 'ALLOWED_WITH_VENTILATION',
+      lightsOut: 'AFTER_TIME',
+      lightsOutTime: '23:00',
+      homeVisit: 'BIWEEKLY',
+      smoking: 'NON_SMOKER',
+      refrigerator: 'DECIDE_AFTER_DISCUSSION',
+      alarm: 'VIBRATION',
+    });
+
+    expect(sections[0].items[0]).toEqual({ q: '취침', a: '23:00' });
+    expect(sections[0].items.find((item) => item.q === '귀가')).toEqual({ q: '귀가', a: '고정적' });
+    expect(sections[1].items.find((item) => item.q === '알람')).toEqual({ q: '알람', a: '진동' });
+  });
+
+  it('roomRuleToChecklistForm은 백엔드 규칙을 수정 폼 상태로 변환한다', () => {
+    expect(roomRuleToChecklistForm({
+      bedtime: '23:00',
+      wakeUp: '07:00',
+      hairDryer: '12:00-19:00',
+      returnHome: 'FLEXIBLE',
+      cleaning: 'REGULAR',
+      phoneCall: 'ALLOWED',
+      sleepLight: 'DARK',
+      sleepHabit: 'MILD',
+      snoring: 'MILD_OR_NONE',
+      showerTime: 'EVENING',
+      eating: 'ALLOWED_WITH_VENTILATION',
+      lightsOut: 'AFTER_TIME',
+      lightsOutTime: '23:00',
+      homeVisit: 'BIWEEKLY',
+      smoking: 'NON_SMOKER',
+      refrigerator: 'DECIDE_AFTER_DISCUSSION',
+      alarm: 'VIBRATION',
+      earphone: 'ALWAYS',
+      keyskin: 'FLEXIBLE',
+      heat: 'MODERATE',
+      cold: 'LESS_SENSITIVE',
+      study: 'INSIDE_DORM',
+      trashCan: 'INDIVIDUAL',
+    })).toMatchObject({
+      sleep: { start: 23, end: 0 },
+      wake: { start: 7, end: 0 },
+      dryer: { start: 12, end: 19 },
+      homing: '유동적',
+      cleaning: '주기적',
+      call: '가능',
+      dim: '어두움',
+      lightsOut: '시간 지정',
+      lightsOutHour: 23,
+      trash: '개별',
+    });
+  });
+
+  it('checklistFormToRoomRuleRequest는 수정 폼과 방 정보를 백엔드 요청으로 변환한다', () => {
+    const request = checklistFormToRoomRuleRequest({
+      sleep: { start: 23, end: 1 },
+      wake: { start: 7, end: 9 },
+      dryer: null,
+      homing: '고정적',
+      cleaning: '주기적',
+      call: '가능',
+      dim: '어두움',
+      sleepHabit: '약함',
+      snore: '약함~없음',
+      shower: '저녁',
+      eating: '가능+환기필수',
+      lightsOut: '시간 지정',
+      lightsOutHour: 23,
+      visitHome: '2주',
+      smoke: '비흡연',
+      fridge: '협의 후 결정',
+      alarm: '진동',
+      earphone: '항상',
+      skinCare: '유동적',
+      hot: '중간',
+      cold: '중간',
+      study: '기숙사 안',
+      trash: '개별',
+    }, {
+      roomType: 'TYPE_2',
+      capacity: 4,
+      residencePeriod: 'SEMESTER',
+    });
+
+    expect(request).toMatchObject({
+      bedtime: '23:00-01:00',
+      wakeUp: '07:00-09:00',
+      returnHome: 'FIXED',
+      returnHomeTime: '23:00',
+      cleaning: 'REGULAR',
+      phoneCall: 'ALLOWED',
+      sleepLight: 'DARK',
+      sleepHabit: 'MILD',
+      snoring: 'MILD_OR_NONE',
+      showerTime: 'EVENING',
+      eating: 'ALLOWED_WITH_VENTILATION',
+      lightsOut: 'AFTER_TIME',
+      lightsOutTime: '23:00',
+      homeVisit: 'BIWEEKLY',
+      smoking: 'NON_SMOKER',
+      refrigerator: 'DECIDE_AFTER_DISCUSSION',
+      hairDryer: null,
+      alarm: 'VIBRATION',
+      earphone: 'ALWAYS',
+      keyskin: 'FLEXIBLE',
+      heat: 'MODERATE',
+      cold: 'MODERATE',
+      study: 'INSIDE_DORM',
+      trashCan: 'INDIVIDUAL',
+      roomType: 'TYPE_2',
+      capacity: 4,
+      residencePeriod: 'SEMESTER',
+    });
+  });
+
+  it('createRoomDraftToRequest는 생성 draft와 체크리스트 폼을 POST /api/rooms 요청으로 변환한다', () => {
+    const request = createRoomDraftToRequest({
+      title: '새 룸메 구해요',
+      dorm: '2생활관',
+      roomSize: '4인실',
+      residencePeriod: 'SEMESTER',
+      notes: '조용히 지내요',
+    }, {
+      sleep: { start: 23, end: 1 },
+      wake: { start: 7, end: 9 },
+      dryer: null,
+      homing: '고정적',
+      cleaning: '주기적',
+      call: '가능',
+      dim: '어두움',
+      sleepHabit: '약함',
+      snore: '약함~없음',
+      shower: '저녁',
+      eating: '가능+환기필수',
+      lightsOut: '시간 지정',
+      lightsOutHour: 23,
+      visitHome: '2주',
+      smoke: '비흡연',
+      fridge: '협의 후 결정',
+      alarm: '진동',
+      earphone: '항상',
+      skinCare: '유동적',
+      hot: '중간',
+      cold: '중간',
+      study: '기숙사 안',
+      trash: '개별',
+    });
+
+    expect(request).toMatchObject({
+      roomType: 'TYPE_2',
+      capacity: 4,
+      residencePeriod: 'SEMESTER',
+      title: '새 룸메 구해요',
+      notes: '조용히 지내요',
+      rule: {
+        bedtime: '23:00-01:00',
+        wakeUp: '07:00-09:00',
+        returnHome: 'FIXED',
+      },
+    });
+    expect(request.rule).not.toHaveProperty('roomType');
+    expect(request.rule).not.toHaveProperty('capacity');
+    expect(request.rule).not.toHaveProperty('residencePeriod');
+  });
+});

--- a/src/shared/api/auth.js
+++ b/src/shared/api/auth.js
@@ -28,6 +28,17 @@ export function clearProfileCache() {
   window.localStorage.removeItem(PROFILE_STORAGE_KEY);
 }
 
+export function getCachedUserNo() {
+  if (typeof window === 'undefined') return '';
+  try {
+    const raw = window.localStorage.getItem(PROFILE_STORAGE_KEY);
+    if (!raw) return '';
+    return JSON.parse(raw).userNo || '';
+  } catch {
+    return '';
+  }
+}
+
 export async function login(email, password) {
   await apiRequest('/api/users/login', {
     method: 'POST',

--- a/src/shared/api/chat.js
+++ b/src/shared/api/chat.js
@@ -1,0 +1,26 @@
+import * as client from './client';
+
+export function loadMyChatRooms() {
+  return client.apiRequestWithAuth('/api/chat/rooms');
+}
+
+export function loadChatMessages(chatRoomNo, cursor) {
+  const query = cursor ? `?cursor=${encodeURIComponent(cursor)}` : '';
+  return client.apiRequestWithAuth(`/api/chat/rooms/${chatRoomNo}/messages${query}`);
+}
+
+export function markChatRoomRead(chatRoomNo) {
+  return client.apiRequestWithAuth(`/api/chat/rooms/${chatRoomNo}/read`, { method: 'POST' });
+}
+
+export function leaveChatRoom(chatRoomNo) {
+  return client.apiRequestWithAuth(`/api/chat/rooms/${chatRoomNo}/leave`, { method: 'DELETE' });
+}
+
+export function getChatRoomMembers(chatRoomNo) {
+  return client.apiRequestWithAuth(`/api/chat/rooms/${chatRoomNo}/members`);
+}
+
+export function getOrCreateDirectChatRoom(roomNo, applicantUserNo) {
+  return client.apiRequestWithAuth(`/api/rooms/${roomNo}/direct-chat/${applicantUserNo}`, { method: 'POST' });
+}

--- a/src/shared/api/chat.test.js
+++ b/src/shared/api/chat.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as client from './client';
+import {
+  loadMyChatRooms, loadChatMessages, markChatRoomRead,
+  leaveChatRoom, getChatRoomMembers, getOrCreateDirectChatRoom,
+} from './chat';
+
+describe('chat api', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(client, 'apiRequestWithAuth').mockResolvedValue('OK');
+  });
+
+  it('loadMyChatRooms는 GET /api/chat/rooms 호출', async () => {
+    await loadMyChatRooms();
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/chat/rooms');
+  });
+
+  it('loadChatMessages는 cursor 없이 호출 가능', async () => {
+    await loadChatMessages('R1');
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/chat/rooms/R1/messages');
+  });
+
+  it('loadChatMessages는 cursor를 쿼리로 인코딩', async () => {
+    await loadChatMessages('R1', 'cur:1');
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/chat/rooms/R1/messages?cursor=cur%3A1');
+  });
+
+  it('markChatRoomRead는 POST', async () => {
+    await markChatRoomRead('R1');
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/chat/rooms/R1/read', { method: 'POST' });
+  });
+
+  it('leaveChatRoom은 DELETE', async () => {
+    await leaveChatRoom('R1');
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/chat/rooms/R1/leave', { method: 'DELETE' });
+  });
+
+  it('getChatRoomMembers는 GET members', async () => {
+    await getChatRoomMembers('R1');
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/chat/rooms/R1/members');
+  });
+
+  it('getOrCreateDirectChatRoom은 POST direct-chat', async () => {
+    await getOrCreateDirectChatRoom('ROOM1', 'USER9');
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/rooms/ROOM1/direct-chat/USER9', { method: 'POST' });
+  });
+});

--- a/src/shared/api/chatSocket.js
+++ b/src/shared/api/chatSocket.js
@@ -5,11 +5,16 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
 
 let client = null;
 let connectPromise = null;
+let pendingResolvers = [];
 
-// 단일 STOMP 연결을 보장한다. 이미 연결되어 있으면 즉시 resolve.
 export function connectChatSocket() {
   if (client && client.connected) return Promise.resolve(client);
   if (connectPromise) return connectPromise;
+
+  // client 존재하지만 재연결 중 — 다음 onConnect를 기다린다
+  if (client) {
+    return new Promise((resolve) => pendingResolvers.push(resolve));
+  }
 
   connectPromise = new Promise((resolve, reject) => {
     const stomp = new Client({
@@ -17,9 +22,23 @@ export function connectChatSocket() {
       reconnectDelay: 3000,
       heartbeatIncoming: 10000,
       heartbeatOutgoing: 10000,
-      onConnect: () => resolve(stomp),
-      onStompError: (frame) => reject(new Error(frame.headers?.message || 'STOMP error')),
-      onWebSocketError: (e) => reject(e),
+      onConnect: () => {
+        // 연결(재연결 포함) 성공 시 stale promise 초기화
+        connectPromise = null;
+        const pending = pendingResolvers.splice(0);
+        pending.forEach((r) => r(stomp));
+        resolve(stomp);
+      },
+      onStompError: (frame) => {
+        connectPromise = null;
+        client = null;
+        reject(new Error(frame.headers?.message || 'STOMP error'));
+      },
+      onWebSocketError: (e) => {
+        connectPromise = null;
+        client = null;
+        reject(e);
+      },
     });
     stomp.activate();
     client = stomp;
@@ -49,5 +68,6 @@ export function disconnectChatSocket() {
     client.deactivate();
     client = null;
     connectPromise = null;
+    pendingResolvers = [];
   }
 }

--- a/src/shared/api/chatSocket.js
+++ b/src/shared/api/chatSocket.js
@@ -1,0 +1,53 @@
+import { Client } from '@stomp/stompjs';
+import SockJS from 'sockjs-client';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+
+let client = null;
+let connectPromise = null;
+
+// 단일 STOMP 연결을 보장한다. 이미 연결되어 있으면 즉시 resolve.
+export function connectChatSocket() {
+  if (client && client.connected) return Promise.resolve(client);
+  if (connectPromise) return connectPromise;
+
+  connectPromise = new Promise((resolve, reject) => {
+    const stomp = new Client({
+      webSocketFactory: () => new SockJS(`${API_BASE_URL}/ws`),
+      reconnectDelay: 3000,
+      heartbeatIncoming: 10000,
+      heartbeatOutgoing: 10000,
+      onConnect: () => resolve(stomp),
+      onStompError: (frame) => reject(new Error(frame.headers?.message || 'STOMP error')),
+      onWebSocketError: (e) => reject(e),
+    });
+    stomp.activate();
+    client = stomp;
+  });
+  return connectPromise;
+}
+
+// 토픽 구독. 콜백에는 파싱된 JSON 객체를 넘긴다. 반환된 함수로 구독 해제.
+export async function subscribe(destination, callback) {
+  const stomp = await connectChatSocket();
+  const sub = stomp.subscribe(destination, (frame) => {
+    let payload = frame.body;
+    try { payload = JSON.parse(frame.body); } catch { /* keep raw */ }
+    callback(payload);
+  });
+  return () => sub.unsubscribe();
+}
+
+// 메시지 전송. body는 객체.
+export async function publish(destination, body) {
+  const stomp = await connectChatSocket();
+  stomp.publish({ destination, body: JSON.stringify(body) });
+}
+
+export function disconnectChatSocket() {
+  if (client) {
+    client.deactivate();
+    client = null;
+    connectPromise = null;
+  }
+}

--- a/src/shared/api/room.js
+++ b/src/shared/api/room.js
@@ -3,7 +3,7 @@ import * as client from './client';
 export function submitRoomApplication(roomNo, message) {
   return client.apiRequestWithAuth(`/api/rooms/${roomNo}/request`, {
     method: 'POST',
-    body: { additionalMessage: message },
+    body: { introduction: message },
   });
 }
 
@@ -11,6 +11,12 @@ export function createRoom(request) {
   return client.apiRequestWithAuth('/api/rooms', {
     method: 'POST',
     body: request,
+  });
+}
+
+export function deleteRoom(roomNo) {
+  return client.apiRequestWithAuth(`/api/rooms/${roomNo}`, {
+    method: 'DELETE',
   });
 }
 

--- a/src/shared/api/room.js
+++ b/src/shared/api/room.js
@@ -1,0 +1,53 @@
+import * as client from './client';
+
+export function submitRoomApplication(roomNo, message) {
+  return client.apiRequestWithAuth(`/api/rooms/${roomNo}/request`, {
+    method: 'POST',
+    body: { additionalMessage: message },
+  });
+}
+
+export function createRoom(request) {
+  return client.apiRequestWithAuth('/api/rooms', {
+    method: 'POST',
+    body: request,
+  });
+}
+
+export function loadApplications(roomNo) {
+  return client.apiRequestWithAuth(`/api/rooms/${roomNo}/applications`);
+}
+
+export function approveApplication(roomNo, requestNo) {
+  return client.apiRequestWithAuth(`/api/rooms/${roomNo}/request/${requestNo}/approve`, {
+    method: 'POST',
+  });
+}
+
+export function rejectApplication(requestNo) {
+  return client.apiRequestWithAuth(`/api/request/${requestNo}/reject`, {
+    method: 'POST',
+  });
+}
+
+export function loadMyRoomRule(roomNo) {
+  return client.apiRequestWithAuth(`/api/rooms/${roomNo}/rule`);
+}
+
+export function updateMyRoomRule(roomNo, request) {
+  return client.apiRequestWithAuth(`/api/rooms/me/rule?roomNo=${encodeURIComponent(roomNo)}`, {
+    method: 'PUT',
+    body: request,
+  });
+}
+
+export function loadMyRoommates() {
+  return client.apiRequestWithAuth('/api/rooms/me/roommates');
+}
+
+export function updateRoomTitle(roomNo, request) {
+  return client.apiRequestWithAuth(`/api/rooms/me/title?roomNo=${encodeURIComponent(roomNo)}`, {
+    method: 'PUT',
+    body: request,
+  });
+}

--- a/src/shared/api/room.test.js
+++ b/src/shared/api/room.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as client from './client';
+import {
+  submitRoomApplication,
+  loadApplications,
+  approveApplication,
+  rejectApplication,
+  loadMyRoomRule,
+  updateMyRoomRule,
+  loadMyRoommates,
+  updateRoomTitle,
+  createRoom,
+} from './room';
+
+describe('room api', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(client, 'apiRequestWithAuth').mockResolvedValue('OK');
+  });
+
+  it('submitRoomApplication은 POST /api/rooms/42/request with body', async () => {
+    await submitRoomApplication(42, '안녕하세요');
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/rooms/42/request', {
+      method: 'POST',
+      body: { additionalMessage: '안녕하세요' },
+    });
+  });
+
+  it('submitRoomApplication은 빈 문자열 message도 body에 포함', async () => {
+    await submitRoomApplication(42, '');
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/rooms/42/request', {
+      method: 'POST',
+      body: { additionalMessage: '' },
+    });
+  });
+
+  it('loadApplications는 GET /api/rooms/42/applications 호출 및 목록 반환', async () => {
+    const mockList = [{ id: 1 }, { id: 2 }];
+    vi.spyOn(client, 'apiRequestWithAuth').mockResolvedValue(mockList);
+    const result = await loadApplications(42);
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/rooms/42/applications');
+    expect(result).toEqual(mockList);
+  });
+
+  it('approveApplication은 POST /api/rooms/42/request/7/approve 호출', async () => {
+    await approveApplication(42, 7);
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/rooms/42/request/7/approve', {
+      method: 'POST',
+    });
+  });
+
+  it('rejectApplication은 POST /api/request/7/reject 호출', async () => {
+    await rejectApplication(7);
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/request/7/reject', {
+      method: 'POST',
+    });
+  });
+
+  it('loadMyRoomRule은 GET /api/rooms/42/rule 호출 및 규칙 반환', async () => {
+    const mockRule = { bedtime: '23:00-01:00' };
+    vi.spyOn(client, 'apiRequestWithAuth').mockResolvedValue(mockRule);
+    const result = await loadMyRoomRule(42);
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/rooms/42/rule');
+    expect(result).toEqual(mockRule);
+  });
+
+  it('updateMyRoomRule은 PUT /api/rooms/me/rule?roomNo=42 호출', async () => {
+    const request = { bedtime: '23:00-01:00' };
+    await updateMyRoomRule(42, request);
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/rooms/me/rule?roomNo=42', {
+      method: 'PUT',
+      body: request,
+    });
+  });
+
+  it('loadMyRoommates는 GET /api/rooms/me/roommates 호출 및 목록 반환', async () => {
+    const mockList = [{ userNo: 'u1' }];
+    vi.spyOn(client, 'apiRequestWithAuth').mockResolvedValue(mockList);
+    const result = await loadMyRoommates();
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/rooms/me/roommates');
+    expect(result).toEqual(mockList);
+  });
+
+  it('updateRoomTitle은 PUT /api/rooms/me/title?roomNo=42 호출', async () => {
+    await updateRoomTitle(42, { title: '새 제목', notes: '소개' });
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/rooms/me/title?roomNo=42', {
+      method: 'PUT',
+      body: { title: '새 제목', notes: '소개' },
+    });
+  });
+
+  it('createRoom은 POST /api/rooms 호출', async () => {
+    const request = { title: '모집방', roomType: 'TYPE_2', capacity: 4, residencePeriod: 'SEMESTER', rule: {} };
+    await createRoom(request);
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/rooms', {
+      method: 'POST',
+      body: request,
+    });
+  });
+});

--- a/src/shared/api/room.test.js
+++ b/src/shared/api/room.test.js
@@ -22,7 +22,7 @@ describe('room api', () => {
     await submitRoomApplication(42, '안녕하세요');
     expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/rooms/42/request', {
       method: 'POST',
-      body: { additionalMessage: '안녕하세요' },
+      body: { introduction: '안녕하세요' },
     });
   });
 
@@ -30,7 +30,7 @@ describe('room api', () => {
     await submitRoomApplication(42, '');
     expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/rooms/42/request', {
       method: 'POST',
-      body: { additionalMessage: '' },
+      body: { introduction: '' },
     });
   });
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,11 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: { port: 5173 },
+  define: {
+    global: 'globalThis',
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.{js,jsx}'],
+  },
 });


### PR DESCRIPTION
# 📝 Pull Request Template

## 📌 제목
> **[FIX] 채팅 서버 연동 — mock 제거 및 REST/WebSocket 실시간 연결**

---

## 📢 요약

채팅 목록·채팅 상세·신청자 관리·방 상세 화면의 하드코딩 mock 데이터를 전면 제거하고, 실제 REST API 및 STOMP/WebSocket을 연결했습니다.

🔗 **연관 이슈**: Resolves #17

---

## 🚀 PR 유형
> **해당하는 항목에 체크해주세요.**

- [ ] ✨ 새로운 기능 추가
- [x] 🐛 버그 수정
- [x] 🎨 CSS/UI 디자인 변경
- [ ] 🔧 코드에 영향 없는 변경(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 🔨 코드 리팩토링
- [ ] 📝 주석 추가 및 수정
- [ ] 📄 문서 수정
- [x] 🧪 테스트 추가 또는 리팩토링
- [ ] 🏗️ 빌드 및 패키지 매니저 수정
- [ ] 📂 파일 또는 폴더명 수정
- [ ] 🗑️ 파일 또는 폴더 삭제

---

## 📜 상세 설명

### 1. WebSocket 클라이언트 (`chatSocket.js`)

`@stomp/stompjs` + `sockjs-client` 기반 싱글턴 STOMP 클라이언트를 구현했습니다.

- 재연결 딜레이 3초, heartbeat 10초 설정
- 연결 중 추가 요청은 `pendingResolvers`로 큐잉하여 중복 연결 방지
- `subscribe(destination, callback)` — JSON 자동 파싱, 구독 해제 함수 반환
- `publish(destination, body)` — 객체를 JSON으로 직렬화하여 전송
- `disconnectChatSocket()` — 싱글턴 정리

### 2. 채팅 목록 API 연동 (`ChatListScreen`)

| 변경 전 | 변경 후 |
|---------|---------|
| `CHATS` 하드코딩 배열 | `loadMyChatRooms()` REST 호출 |
| `/chat/group` 고정 경로 | `/chat/group/:chatRoomNo` 동적 경로 |
| 빈 상태 없음 | 채팅방 없을 때 모집방 만들기 CTA 노출 |

### 3. 개인 알림 구독 (`ChatNotificationGate`)

앱 최상단에 마운트되어 로그인 상태에서 `/user/queue/notification`을 구독합니다.

| 알림 타입 | 처리 |
|-----------|------|
| `ROOM_DELETED` | 알럿 표시 후 `/chat`으로 이동 |
| `KICKED_FROM_ROOM` | 알럿 표시 후 `/chat`으로 이동 |

### 4. 채팅 상세 화면 실시간 연결

- mock 메시지 배열 → `loadChatMessages(chatRoomNo)` REST 초기 로드
- 입장 시 STOMP `/topic/chat-room/{chatRoomNo}` 구독, 퇴장 시 구독 해제
- `ChatAttachmentCard` 제거(서버 미지원), `ChatMessageItem` 추가
  - `messageType === 'SYSTEM'` → 중앙 회색 텍스트
  - `messageType === 'TEXT'` → `ChatBubble` (기존 동작 유지)
- `ChatComposer`에서 파일/이미지 첨부 UI 제거

### 5. 방 목록·신청자·내 방 API 연동

- `room.js` — `loadApplications`, `approveApplication`, `rejectApplication`, `loadMyRoommates`, `deleteRoom`, `loadMyRoomRule`, `updateRoomTitle`
- `chat.js` — `getOrCreateDirectChatRoom` 추가 → 방 상세의 DM 버튼에서 채팅방 번호를 서버에서 받아 이동
- `roomData.js` — 백엔드 응답 → 컴포넌트 모델 변환 유틸 (`normalizeRoom`, `roommateToMember`, `roomRuleToChecklist`)
- `ApplicantsListScreen` — mock `APPLICANTS` 제거, 승인/거절 API 호출 후 로컬 상태 갱신

### 6. unreadCount 버그 수정 (`unreadSync.js`)

- `applyReadReceipt(rooms, chatRoomNo)` — 읽음 처리 시 해당 방의 `unreadCount`를 0으로 갱신
- `appendMessage(rooms, message)` — 신규 메시지 수신 시 현재 열려 있지 않은 방의 unread 카운트 증가

---

## ✅ PR 체크리스트
> **PR이 다음 요구 사항을 충족하는지 확인해주세요.**

- [x] 🔹 커밋 메시지 컨벤션을 준수했습니다. ([Commit message convention 참고](#))
- [x] 🔹 변경 사항에 대한 테스트를 수행했습니다. (버그 수정/기능 테스트)
- [ ] 🔹 관련 문서를 업데이트했습니다. (필요한 경우)

---

## 📜 기타
> **리뷰어가 알면 좋을 추가 사항을 적어주세요.**

- BE `#93` PR에서 방 삭제/강퇴 시 `/queue/notification` 개인 알림이 추가되었고, 이 PR의 `ChatNotificationGate`가 그 알림을 수신합니다. DIRECT 채팅방을 열고 있는 사용자는 `/topic/`과 `/queue/` 양쪽으로 알림을 받을 수 있어 FE에서 중복 처리 방지 guard가 필요합니다.
- `chatSocket.js`는 싱글턴으로 관리되므로 컴포넌트 언마운트 시 구독 해제 함수만 호출하면 되고, STOMP 연결 자체는 유지됩니다.