### PR TITLE
[FIX] 마이페이지·방 관리 잔여 API 연동 — 프로필/체크리스트/신청내역/북마크/방만들기 게이팅/내보내기/방확정

### DIFF
--- a/src/features/checklist/pages/Details.jsx
+++ b/src/features/checklist/pages/Details.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { Icon, StatusBar, Avatar, goBack } from '../../../shared/components';
 import { logout as logoutUser, getCachedUserNo } from '../../../shared/api/auth';
-import { loadMyRoom, loadNotifications, markNotificationRead } from '../../../shared/api/home';
+import {
+  loadMyRoom, loadNotifications, markNotificationRead,
+  loadMyChecklist, createUserChecklist, updateUserChecklist,
+} from '../../../shared/api/home';
 import { submitRoomApplication, approveApplication, rejectApplication, loadMyRoomRule, updateMyRoomRule, createRoom } from '../../../shared/api/room';
 import { ChatMessageItem, ChatComposer } from '../../chat';
 import { getOrCreateDirectChatRoom, loadChatMessages, markChatRoomRead, leaveChatRoom } from '../../../shared/api/chat';
@@ -11,6 +14,7 @@ import { applyReadReceipt, appendMessage } from '../../chat/unreadSync';
 import { openNotificationStream } from '../../../shared/api/notificationStream';
 import {
   checklistFormToRoomRuleRequest,
+  checklistFormToUserChecklistRequest,
   createRoomDraftToRequest,
   defaultRoomChecklistForm,
   roomRuleToChecklistForm,
@@ -299,6 +303,7 @@ export function ChecklistEditScreen({ mode = 'personal' }) {
   const isRoomCreate = mode === 'room';
   const isRoomEdit = mode === 'roomEdit';
   const isRoom = isRoomCreate || isRoomEdit;
+  const isPersonal = !isRoom;
   const [v, setV] = React.useState(isRoomCreate ? {
     sleep: { start: 23, end: 1 },
     wake: { start: 7, end: 9 },
@@ -313,6 +318,9 @@ export function ChecklistEditScreen({ mode = 'personal' }) {
   const [roomContext, setRoomContext] = React.useState(null);
   const [roomRuleLoading, setRoomRuleLoading] = React.useState(isRoomEdit);
   const [roomRuleSaving, setRoomRuleSaving] = React.useState(false);
+  const [personalChecklistExists, setPersonalChecklistExists] = React.useState(false);
+  const [personalLoading, setPersonalLoading] = React.useState(isPersonal);
+  const [personalSaving, setPersonalSaving] = React.useState(false);
   const scrollRef = React.useRef(null);
 
   React.useEffect(() => {
@@ -330,6 +338,21 @@ export function ChecklistEditScreen({ mode = 'personal' }) {
     return () => { mounted = false; };
   }, [isRoomEdit]);
 
+  React.useEffect(() => {
+    if (!isPersonal) return undefined;
+    let mounted = true;
+    setPersonalLoading(true);
+    loadMyChecklist()
+      .then((checklist) => {
+        if (!mounted) return;
+        setV(roomRuleToChecklistForm(checklist));
+        setPersonalChecklistExists(true);
+      })
+      .catch(() => { if (mounted) setPersonalChecklistExists(false); })
+      .finally(() => { if (mounted) setPersonalLoading(false); });
+    return () => { mounted = false; };
+  }, [isPersonal]);
+
   const saveRoomRule = () => {
     if (!roomContext || roomRuleSaving) return;
     setRoomRuleSaving(true);
@@ -337,6 +360,17 @@ export function ChecklistEditScreen({ mode = 'personal' }) {
       .then(() => navigate('/rooms/checklist'))
       .catch((e) => alert(e?.message || '방 체크리스트를 저장하지 못했어요.'))
       .finally(() => setRoomRuleSaving(false));
+  };
+
+  const savePersonalChecklist = () => {
+    if (personalSaving) return;
+    setPersonalSaving(true);
+    const request = checklistFormToUserChecklistRequest(v);
+    const call = personalChecklistExists ? updateUserChecklist(request) : createUserChecklist(request);
+    call
+      .then(() => navigate('/me'))
+      .catch((e) => alert(e?.message || '체크리스트를 저장하지 못했어요.'))
+      .finally(() => setPersonalSaving(false));
   };
 
   const handleScroll = () => {
@@ -395,13 +429,16 @@ export function ChecklistEditScreen({ mode = 'personal' }) {
       <TopNav
         title="내 체크리스트"
         backTo="/me"
-        right={<button onClick={() => navigate('/me')} style={{ background: 'transparent', border: 0, fontSize: 13, color: 'var(--brand)', fontWeight: 700, cursor: 'pointer' }}>저장</button>}
+        right={<button onClick={savePersonalChecklist} disabled={personalLoading || personalSaving} style={{ background: 'transparent', border: 0, fontSize: 13, color: 'var(--brand)', fontWeight: 700, cursor: personalLoading || personalSaving ? 'not-allowed' : 'pointer', opacity: personalLoading || personalSaving ? 0.45 : 1 }}>{personalSaving ? '저장 중' : '저장'}</button>}
       />
       }
 
       <div ref={scrollRef} onScroll={handleScroll} className="scroll" style={{ padding: isRoom ? '12px 20px 0' : '0 20px' }}>
         {isRoomEdit && roomRuleLoading && (
           <div style={{ padding: 24, textAlign: 'center', color: 'var(--ink-3)', fontSize: 13 }}>방 체크리스트를 불러오는 중...</div>
+        )}
+        {isPersonal && personalLoading && (
+          <div style={{ padding: 24, textAlign: 'center', color: 'var(--ink-3)', fontSize: 13 }}>체크리스트를 불러오는 중...</div>
         )}
         {/* Section 1 */}
         <div style={{ padding: '10px 0 8px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
@@ -545,7 +582,7 @@ export function ChecklistEditScreen({ mode = 'personal' }) {
       }
       {!isRoom &&
       <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, padding: '14px 16px 30px', background: 'linear-gradient(180deg, transparent 0%, var(--bg) 30%)' }}>
-          <button onClick={() => navigate('/me')} className="btn full" style={{ height: 52 }}>저장</button>
+          <button onClick={savePersonalChecklist} disabled={personalLoading || personalSaving} className="btn full" style={{ height: 52, opacity: personalLoading || personalSaving ? 0.45 : 1 }}>{personalSaving ? '저장 중...' : '저장'}</button>
         </div>
       }
     </div>);

--- a/src/features/checklist/pages/Details.jsx
+++ b/src/features/checklist/pages/Details.jsx
@@ -2,22 +2,19 @@ import React from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { Icon, StatusBar, Avatar, goBack } from '../../../shared/components';
 import { logout as logoutUser, getCachedUserNo } from '../../../shared/api/auth';
-import { loadMyRoom } from '../../../shared/api/home';
+import { loadMyRoom, loadNotifications, markNotificationRead } from '../../../shared/api/home';
 import { submitRoomApplication, approveApplication, rejectApplication, loadMyRoomRule, updateMyRoomRule, createRoom } from '../../../shared/api/room';
 import { ChatMessageItem, ChatComposer } from '../../chat';
 import { getOrCreateDirectChatRoom, loadChatMessages, markChatRoomRead, leaveChatRoom } from '../../../shared/api/chat';
 import { subscribe, publish } from '../../../shared/api/chatSocket';
 import { applyReadReceipt, appendMessage } from '../../chat/unreadSync';
+import { openNotificationStream } from '../../../shared/api/notificationStream';
 import {
   checklistFormToRoomRuleRequest,
   createRoomDraftToRequest,
   defaultRoomChecklistForm,
   roomRuleToChecklistForm,
 } from '../../rooms/roomData';
-import { logout as logoutUser } from '../../../shared/api/auth';
-import { loadNotifications, markNotificationRead } from '../../../shared/api/home';
-import { openNotificationStream } from '../../../shared/api/notificationStream';
-import { ChatBubble, ChatComposer, ChatAttachmentCard } from '../../chat';
 
 // details.jsx — Detail screens for each tab
 

--- a/src/features/checklist/pages/Details.jsx
+++ b/src/features/checklist/pages/Details.jsx
@@ -5,7 +5,7 @@ import { logout as logoutUser, getCachedUserNo } from '../../../shared/api/auth'
 import {
   loadMyRoom, loadNotifications, markNotificationRead,
   loadMyChecklist, createUserChecklist, updateUserChecklist,
-  loadMyAppliedRooms,
+  loadMyAppliedRooms, loadLikedRooms, unlikeRoom,
 } from '../../../shared/api/home';
 import { submitRoomApplication, approveApplication, rejectApplication, loadMyRoomRule, updateMyRoomRule, createRoom, cancelRoomApplication } from '../../../shared/api/room';
 import { ChatMessageItem, ChatComposer } from '../../chat';
@@ -2466,41 +2466,6 @@ export function MyApplicationsScreen() {
 }
 
 // ─── Bookmarks List ──────────────────────────────────────────
-const BOOKMARK_MOCK = [
-  {
-    id: 1,
-    room: '아침형 룸메 구해요',
-    dorm: '2생활관',
-    roomType: '4인실',
-    savedAt: '2026.05.19',
-    recruiting: true,
-  },
-  {
-    id: 2,
-    room: '청결 최우선! 조용한 룸메 모집',
-    dorm: '1생활관',
-    roomType: '2인실',
-    savedAt: '2026.05.12',
-    recruiting: true,
-  },
-  {
-    id: 3,
-    room: '밤형 인간 환영합니다',
-    dorm: '3생활관',
-    roomType: '4인실',
-    savedAt: '2026.04.28',
-    recruiting: false,
-  },
-  {
-    id: 4,
-    room: '여성 전용 · 취준생 룸메 구해요',
-    dorm: '2생활관',
-    roomType: '2인실',
-    savedAt: '2026.04.15',
-    recruiting: false,
-  },
-];
-
 const BOOKMARK_TABS = [
   { key: 'all', label: '전체' },
   { key: 'recruiting', label: '모집중' },
@@ -2510,13 +2475,32 @@ const BOOKMARK_TABS = [
 export function BookmarksScreen() {
   const navigate = useNavigate();
   const [tab, setTab] = React.useState('all');
-  const [bookmarks, setBookmarks] = React.useState(BOOKMARK_MOCK);
+  const [bookmarks, setBookmarks] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState('');
+
+  React.useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    setError('');
+    loadLikedRooms()
+      .then((rooms) => {
+        if (mounted) setBookmarks((Array.isArray(rooms) ? rooms : []).map(normalizeRoom));
+      })
+      .catch(() => { if (mounted) setError('북마크를 불러오지 못했어요.'); })
+      .finally(() => { if (mounted) setLoading(false); });
+    return () => { mounted = false; };
+  }, []);
 
   const filtered = tab === 'all'
     ? bookmarks
     : bookmarks.filter(b => tab === 'recruiting' ? b.recruiting : !b.recruiting);
 
-  const handleRemove = (id) => setBookmarks(prev => prev.filter(b => b.id !== id));
+  const handleRemove = (roomNo) => {
+    unlikeRoom(roomNo)
+      .then(() => setBookmarks((prev) => prev.filter((b) => b.roomNo !== roomNo)))
+      .catch((e) => alert(e?.message || '북마크 해제에 실패했어요.'));
+  };
 
   return (
     <div className="screen">
@@ -2542,7 +2526,13 @@ export function BookmarksScreen() {
       </div>
 
       <div className="scroll" style={{ padding: '0 16px 24px', display: 'flex', flexDirection: 'column', gap: 10 }}>
-        {filtered.length === 0 ? (
+        {loading && (
+          <div style={{ padding: '64px 0', textAlign: 'center', color: 'var(--ink-3)', fontSize: 13 }}>불러오는 중...</div>
+        )}
+        {!loading && error && (
+          <div style={{ padding: '64px 0', textAlign: 'center', color: 'var(--danger)', fontSize: 13 }}>{error}</div>
+        )}
+        {!loading && !error && filtered.length === 0 && (
           <div style={{
             display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
             padding: '64px 0', gap: 12, color: 'var(--ink-4)',
@@ -2552,8 +2542,9 @@ export function BookmarksScreen() {
             </svg>
             <span style={{ fontSize: 14, fontWeight: 500 }}>북마크한 방이 없어요</span>
           </div>
-        ) : filtered.map(b => (
-          <div key={b.id} className="card" style={{ padding: 16 }}>
+        )}
+        {!loading && !error && filtered.map(b => (
+          <div key={b.roomNo} className="card" style={{ padding: 16 }}>
             {/* Room info row */}
             <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14 }}>
               <div style={{
@@ -2568,28 +2559,27 @@ export function BookmarksScreen() {
                 <div style={{
                   fontSize: 15, fontWeight: 700, color: b.recruiting ? 'var(--ink)' : 'var(--ink-3)',
                   overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-                }}>{b.room}</div>
-                <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 3 }}>{b.dorm} · {b.roomType}</div>
+                }}>{b.title}</div>
+                <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 3 }}>{b.dorm} · {b.size}</div>
               </div>
               <span className={b.recruiting ? 'chip brand' : 'chip'} style={{ fontSize: 11, flexShrink: 0 }}>
                 {b.recruiting ? '모집중' : '마감됨'}
               </span>
             </div>
 
-            {/* Divider + meta */}
+            {/* Divider + actions */}
             <div style={{
-              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              display: 'flex', alignItems: 'center', justifyContent: 'flex-end',
               paddingTop: 12, borderTop: '1px solid var(--line)',
             }}>
-              <span style={{ fontSize: 12, color: 'var(--ink-4)' }}>저장일 {b.savedAt}</span>
               <div style={{ display: 'flex', gap: 6 }}>
                 <button
-                  onClick={() => handleRemove(b.id)}
+                  onClick={() => handleRemove(b.roomNo)}
                   className="btn ghost"
                   style={{ fontSize: 12, fontWeight: 600, padding: '7px 14px', borderRadius: 10, height: 'auto', color: 'var(--ink-3)' }}
                 >북마크 해제</button>
                 <button
-                  onClick={() => navigate('/rooms/1', { state: { closed: !b.recruiting } })}
+                  onClick={() => navigate(`/rooms/${b.roomNo}`)}
                   className="btn ghost"
                   style={{ fontSize: 12, fontWeight: 600, padding: '7px 14px', borderRadius: 10, height: 'auto' }}
                 >방 보기</button>

--- a/src/features/checklist/pages/Details.jsx
+++ b/src/features/checklist/pages/Details.jsx
@@ -5,8 +5,9 @@ import { logout as logoutUser, getCachedUserNo } from '../../../shared/api/auth'
 import {
   loadMyRoom, loadNotifications, markNotificationRead,
   loadMyChecklist, createUserChecklist, updateUserChecklist,
+  loadMyAppliedRooms,
 } from '../../../shared/api/home';
-import { submitRoomApplication, approveApplication, rejectApplication, loadMyRoomRule, updateMyRoomRule, createRoom } from '../../../shared/api/room';
+import { submitRoomApplication, approveApplication, rejectApplication, loadMyRoomRule, updateMyRoomRule, createRoom, cancelRoomApplication } from '../../../shared/api/room';
 import { ChatMessageItem, ChatComposer } from '../../chat';
 import { getOrCreateDirectChatRoom, loadChatMessages, markChatRoomRead, leaveChatRoom } from '../../../shared/api/chat';
 import { subscribe, publish } from '../../../shared/api/chatSocket';
@@ -17,7 +18,10 @@ import {
   checklistFormToUserChecklistRequest,
   createRoomDraftToRequest,
   defaultRoomChecklistForm,
+  normalizeRoom,
+  residencePeriodLabel,
   roomRuleToChecklistForm,
+  roomStatusLabel,
 } from '../../rooms/roomData';
 
 // details.jsx — Detail screens for each tab
@@ -2315,60 +2319,37 @@ export function CreateRoomSuccessScreen() {
 }
 
 // ─── My Applications List ────────────────────────────────────
-const APPLY_MOCK = [
-  {
-    id: 1,
-    room: '아침형 룸메 구해요',
-    dorm: '2생활관',
-    roomType: '4인실',
-    appliedAt: '2026.05.20',
-    status: 'waiting',
-    closed: false,
-  },
-  {
-    id: 2,
-    room: '조용하고 청결한 룸메 구합니다',
-    dorm: '3생활관',
-    roomType: '2인실',
-    appliedAt: '2026.05.14',
-    status: 'accepted',
-    closed: false,
-  },
-  {
-    id: 3,
-    room: '밤형 인간 환영',
-    dorm: '1생활관',
-    roomType: '2인실',
-    appliedAt: '2026.04.30',
-    status: 'rejected',
-    closed: true,
-  },
-];
-
-const STATUS_TABS = [
-  { key: 'all', label: '전체' },
-  { key: 'waiting', label: '대기중' },
-  { key: 'accepted', label: '수락됨' },
-  { key: 'rejected', label: '거절됨' },
-];
-
-const STATUS_META = {
-  waiting: { label: '대기중', chipClass: 'chip brand' },
-  accepted: { label: '수락됨', chipClass: 'chip success' },
-  rejected: { label: '거절됨', chipClass: 'chip' },
-};
-
 export function MyApplicationsScreen() {
   const navigate = useNavigate();
-  const [tab, setTab] = React.useState('all');
-  const [applications, setApplications] = React.useState(APPLY_MOCK);
+  const [applications, setApplications] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState('');
   const [cancelTarget, setCancelTarget] = React.useState(null);
+  const [cancelling, setCancelling] = React.useState(false);
 
-  const filtered = tab === 'all' ? applications : applications.filter(a => a.status === tab);
+  React.useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    setError('');
+    loadMyAppliedRooms()
+      .then((rooms) => {
+        if (mounted) setApplications((Array.isArray(rooms) ? rooms : []).map(normalizeRoom));
+      })
+      .catch(() => { if (mounted) setError('신청 내역을 불러오지 못했어요.'); })
+      .finally(() => { if (mounted) setLoading(false); });
+    return () => { mounted = false; };
+  }, []);
 
   const handleCancel = () => {
-    setApplications(prev => prev.filter(a => a.id !== cancelTarget));
-    setCancelTarget(null);
+    if (!cancelTarget || cancelling) return;
+    setCancelling(true);
+    cancelRoomApplication(cancelTarget)
+      .then(() => {
+        setApplications((prev) => prev.filter((a) => a.roomNo !== cancelTarget));
+        setCancelTarget(null);
+      })
+      .catch((e) => alert(e?.message || '신청 취소에 실패했어요.'))
+      .finally(() => setCancelling(false));
   };
 
   return (
@@ -2376,33 +2357,14 @@ export function MyApplicationsScreen() {
       <StatusBar />
       <TopNav title="신청 내역" backTo="/me" />
 
-      {/* Status filter tabs */}
-      <div style={{
-        display: 'flex', gap: 6, padding: '4px 16px 12px',
-        overflowX: 'auto', flexShrink: 0,
-      }}>
-        {STATUS_TABS.map(t => (
-          <button
-            key={t.key}
-            onClick={() => setTab(t.key)}
-            style={{
-              padding: '7px 14px',
-              borderRadius: 999,
-              border: tab === t.key ? 'none' : '1px solid var(--line-2)',
-              background: tab === t.key ? 'var(--ink)' : 'transparent',
-              color: tab === t.key ? 'white' : 'var(--ink-2)',
-              fontSize: 13, fontWeight: tab === t.key ? 700 : 500,
-              fontFamily: 'inherit',
-              cursor: 'pointer',
-              whiteSpace: 'nowrap',
-              flexShrink: 0,
-            }}
-          >{t.label}</button>
-        ))}
-      </div>
-
       <div className="scroll" style={{ padding: '0 16px 24px', display: 'flex', flexDirection: 'column', gap: 10 }}>
-        {filtered.length === 0 ? (
+        {loading && (
+          <div style={{ padding: '64px 0', textAlign: 'center', color: 'var(--ink-3)', fontSize: 13 }}>불러오는 중...</div>
+        )}
+        {!loading && error && (
+          <div style={{ padding: '64px 0', textAlign: 'center', color: 'var(--danger)', fontSize: 13 }}>{error}</div>
+        )}
+        {!loading && !error && applications.length === 0 && (
           <div style={{
             flex: 1, display: 'flex', flexDirection: 'column',
             alignItems: 'center', justifyContent: 'center',
@@ -2411,57 +2373,55 @@ export function MyApplicationsScreen() {
             <Icon.clipboard size={36} />
             <span style={{ fontSize: 14, fontWeight: 500 }}>신청 내역이 없어요</span>
           </div>
-        ) : filtered.map(app => {
-          const sm = STATUS_META[app.status];
-          return (
-            <div key={app.id} className="card" style={{ padding: 16 }}>
-              {/* Room info row */}
-              <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14 }}>
-                <div style={{
-                  width: 44, height: 44, borderRadius: 12,
-                  background: app.status === 'accepted' ? 'var(--brand-soft)' : 'var(--surface-2)',
-                  color: app.status === 'accepted' ? 'var(--brand)' : 'var(--ink-3)',
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  flexShrink: 0,
-                }}>
-                  <Icon.door size={22} />
-                </div>
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{
-                    fontSize: 15, fontWeight: 700, color: 'var(--ink)',
-                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-                  }}>{app.room}</div>
-                  <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 3 }}>
-                    {app.dorm} · {app.roomType}
-                  </div>
-                </div>
-                <span className={sm.chipClass} style={{ fontSize: 11, flexShrink: 0 }}>{sm.label}</span>
-              </div>
-
-              {/* Divider + meta */}
+        )}
+        {!loading && !error && applications.map((app) => (
+          <div key={app.roomNo} className="card" style={{ padding: 16 }}>
+            {/* Room info row */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14 }}>
               <div style={{
-                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                paddingTop: 12, borderTop: '1px solid var(--line)',
+                width: 44, height: 44, borderRadius: 12,
+                background: 'var(--surface-2)',
+                color: 'var(--ink-3)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                flexShrink: 0,
               }}>
-                <span style={{ fontSize: 12, color: 'var(--ink-4)' }}>신청일 {app.appliedAt}</span>
-                <div style={{ display: 'flex', gap: 6 }}>
-                  {app.status === 'waiting' && (
-                    <button
-                      onClick={() => setCancelTarget(app.id)}
-                      className="btn ghost"
-                      style={{ fontSize: 12, fontWeight: 600, padding: '7px 14px', borderRadius: 10, height: 'auto', color: 'var(--danger)' }}
-                    >취소하기</button>
-                  )}
-                  <button
-                    onClick={() => navigate('/rooms/1', { state: { appliedStatus: app.status, closed: app.closed } })}
-                    className="btn ghost"
-                    style={{ fontSize: 12, fontWeight: 600, padding: '7px 14px', borderRadius: 10, height: 'auto' }}
-                  >방 보기</button>
+                <Icon.door size={22} />
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{
+                  fontSize: 15, fontWeight: 700, color: 'var(--ink)',
+                  overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                }}>{app.title}</div>
+                <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 3 }}>
+                  {app.dorm} · {app.size}
                 </div>
+              </div>
+              <span className="chip" style={{ fontSize: 11, flexShrink: 0 }}>{roomStatusLabel(app.roomStatus)}</span>
+            </div>
+
+            {/* Divider + meta */}
+            <div style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              paddingTop: 12, borderTop: '1px solid var(--line)',
+            }}>
+              <span style={{ fontSize: 12, color: 'var(--ink-4)' }}>{residencePeriodLabel(app.residencePeriod)}</span>
+              <div style={{ display: 'flex', gap: 6 }}>
+                {app.roomStatus !== 'COMPLETED' && (
+                  <button
+                    onClick={() => setCancelTarget(app.roomNo)}
+                    className="btn ghost"
+                    style={{ fontSize: 12, fontWeight: 600, padding: '7px 14px', borderRadius: 10, height: 'auto', color: 'var(--danger)' }}
+                  >취소하기</button>
+                )}
+                <button
+                  onClick={() => navigate(`/rooms/${app.roomNo}`)}
+                  className="btn ghost"
+                  style={{ fontSize: 12, fontWeight: 600, padding: '7px 14px', borderRadius: 10, height: 'auto' }}
+                >방 보기</button>
               </div>
             </div>
-          );
-        })}
+          </div>
+        ))}
       </div>
 
       {/* Cancel confirm bottom sheet */}
@@ -2489,9 +2449,10 @@ export function MyApplicationsScreen() {
             </div>
             <button
               onClick={handleCancel}
+              disabled={cancelling}
               className="btn full"
-              style={{ height: 52, background: 'var(--danger)' }}
-            >신청 취소하기</button>
+              style={{ height: 52, background: 'var(--danger)', opacity: cancelling ? 0.6 : 1 }}
+            >{cancelling ? '취소하는 중...' : '신청 취소하기'}</button>
             <button
               onClick={() => setCancelTarget(null)}
               className="btn full ghost"

--- a/src/features/home/pages/Home.jsx
+++ b/src/features/home/pages/Home.jsx
@@ -5,6 +5,7 @@ import { getMe } from '../../../shared/api/auth';
 import { loadCalendarEvents, loadMyRoom, loadNotices, loadNotifications } from '../../../shared/api/home';
 import { openNotificationStream } from '../../../shared/api/notificationStream';
 import { residencePeriodLabel } from '../../rooms';
+import { roomStatusLabel } from '../../rooms/roomData';
 
 // home.jsx — Home tab (calendar + notices + my room shortcut)
 
@@ -104,12 +105,6 @@ const roomTypeLabel = (roomType) => {
   return '방 정보';
 };
 
-
-const roomStatusLabel = (roomStatus) => {
-  if (roomStatus === 'COMPLETED') return '모집 완료';
-  if (roomStatus === 'CONFIRM_PENDING') return '확정 대기';
-  return '모집중';
-};
 
 const formatRemainingTime = (minutes) => {
   const h = Math.floor(minutes / 60);

--- a/src/features/members/pages/Members.jsx
+++ b/src/features/members/pages/Members.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Icon, Avatar, StatusBar, goBack } from '../../../shared/components';
 import { loadMyRoom } from '../../../shared/api/home';
 import { getOrCreateDirectChatRoom, loadMyChatRooms } from '../../../shared/api/chat';
-import { loadMyRoommates } from '../../../shared/api/room';
+import { loadMyRoommates, kickRoommate } from '../../../shared/api/room';
 import { normalizeRoom, roommateToMember } from '../../rooms/roomData';
 
 // members.jsx — 룸메이트 멤버 화면 (방장 시점)
@@ -78,7 +78,7 @@ export const MEMBER_CHECKLISTS = [
   },
 ];
 
-export function MemberCard({ m, defaultOpen = false, onOpenChat }) {
+export function MemberCard({ m, defaultOpen = false, onOpenChat, onKick }) {
   const [open, setOpen] = React.useState(defaultOpen);
   const navigate = useNavigate();
   const hasChecklist = (m.checklist || []).length > 0;
@@ -102,9 +102,16 @@ export function MemberCard({ m, defaultOpen = false, onOpenChat }) {
           <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 2 }}>{m.dept}</div>
         </div>
         {!m.isMe && (
-          <button onClick={() => onOpenChat ? onOpenChat(m) : navigate('/chat')} title="채팅" style={{ width: 36, height: 36, borderRadius: 10, border: 0, background: 'var(--surface-2)', color: 'var(--ink-2)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
-            <Icon.chat size={18}/>
-          </button>
+          <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
+            <button onClick={() => onOpenChat ? onOpenChat(m) : navigate('/chat')} title="채팅" style={{ width: 36, height: 36, borderRadius: 10, border: 0, background: 'var(--surface-2)', color: 'var(--ink-2)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
+              <Icon.chat size={18}/>
+            </button>
+            {onKick && (
+              <button onClick={() => onKick(m)} title="내보내기" style={{ width: 36, height: 36, borderRadius: 10, border: 0, background: 'var(--surface-2)', color: 'var(--danger)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M18 6L6 18" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/></svg>
+              </button>
+            )}
+          </div>
         )}
       </div>
 
@@ -172,6 +179,8 @@ export function MembersScreen() {
   const [groupChatRoomNo, setGroupChatRoomNo] = React.useState(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState('');
+  const [kickTarget, setKickTarget] = React.useState(null);
+  const [kicking, setKicking] = React.useState(false);
 
   React.useEffect(() => {
     let mounted = true;
@@ -201,6 +210,20 @@ export function MembersScreen() {
     getOrCreateDirectChatRoom(room.roomNo, member.userNo)
       .then((chatRoomNo) => navigate('/chat/dm/' + chatRoomNo))
       .catch((e) => alert(e?.message || '채팅방을 열 수 없어요.'));
+  };
+
+  const isHost = members.find((member) => member.isMe)?.role === '방장';
+
+  const handleKick = () => {
+    if (!room?.roomNo || !kickTarget || kicking) return;
+    setKicking(true);
+    kickRoommate(room.roomNo, kickTarget.userNo)
+      .then(() => {
+        setMembers((prev) => prev.filter((m) => m.userNo !== kickTarget.userNo));
+        setKickTarget(null);
+      })
+      .catch((e) => alert(e?.message || '내보내기에 실패했어요.'))
+      .finally(() => setKicking(false));
   };
 
   const currentMembers = room?.members ?? members.length;
@@ -250,7 +273,7 @@ export function MembersScreen() {
         {loading && <div style={{ padding: 24, textAlign: 'center', color: 'var(--ink-3)', fontSize: 13 }}>불러오는 중...</div>}
         {error && <div style={{ padding: 24, textAlign: 'center', color: 'var(--danger)', fontSize: 13 }}>{error}</div>}
         {!loading && !error && members.map((m) => (
-          <MemberCard key={m.id} m={m} defaultOpen={false} onOpenChat={openDirectChat}/>
+          <MemberCard key={m.id} m={m} defaultOpen={false} onOpenChat={openDirectChat} onKick={isHost ? setKickTarget : undefined}/>
         ))}
 
         {/* Empty slots */}
@@ -285,6 +308,39 @@ export function MembersScreen() {
           <Icon.chevron size={14}/>
         </div>
       </div>
+
+      {kickTarget && (
+        <>
+          <div
+            onClick={() => setKickTarget(null)}
+            style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.4)', zIndex: 40 }}
+          />
+          <div style={{
+            position: 'absolute', left: 0, right: 0, bottom: 0,
+            background: 'var(--surface)',
+            borderRadius: '20px 20px 0 0',
+            padding: '24px 20px 36px',
+            zIndex: 41,
+            display: 'flex', flexDirection: 'column', gap: 8,
+          }}>
+            <div style={{ fontSize: 17, fontWeight: 700, marginBottom: 6 }}>{kickTarget.name}님을 내보낼까요?</div>
+            <div style={{ fontSize: 14, color: 'var(--ink-3)', lineHeight: 1.6, marginBottom: 12 }}>
+              내보내면 되돌릴 수 없어요.
+            </div>
+            <button
+              onClick={handleKick}
+              disabled={kicking}
+              className="btn full"
+              style={{ height: 52, background: 'var(--danger)', opacity: kicking ? 0.6 : 1 }}
+            >{kicking ? '내보내는 중...' : '내보내기'}</button>
+            <button
+              onClick={() => setKickTarget(null)}
+              className="btn full ghost"
+              style={{ height: 52 }}
+            >돌아가기</button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/features/profile/pages/MyPage.jsx
+++ b/src/features/profile/pages/MyPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Icon, TabBar, StatusBar, Avatar, goBack } from '../../../shared/components';
+import { updateUserProfile } from '../../../shared/api/auth';
 
 // mypage.jsx — My Page (profile, checklist, settings)
 
@@ -31,10 +32,6 @@ function readProfile() {
   }
 }
 
-function saveProfile(profile) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem(PROFILE_STORAGE_KEY, JSON.stringify(profile));
-}
 
 function ProfilePhoto({ profile, size = 64, style = {} }) {
   if (profile.photo) {
@@ -188,18 +185,18 @@ export function MyPageScreen({ activeTab='me' }) {
 export function ProfileEditScreen() {
   const navigate = useNavigate();
   const [profile, setProfile] = React.useState(readProfile);
+  const [saving, setSaving] = React.useState(false);
   const nickname = profile.displayName;
   const department = profile.department;
   const canSave = nickname.trim().length > 0 && department.trim().length > 0;
 
   const handleSave = () => {
-    if (!canSave) return;
-    saveProfile({
-      ...profile,
-      displayName: nickname.trim(),
-      department: department.trim(),
-    });
-    navigate('/me');
+    if (!canSave || saving) return;
+    setSaving(true);
+    updateUserProfile({ nickname: nickname.trim(), major: department.trim(), grade: profile.grade })
+      .then(() => navigate('/me'))
+      .catch((e) => alert(e?.message || '프로필을 저장하지 못했어요.'))
+      .finally(() => setSaving(false));
   };
 
   const inputBase = {
@@ -255,18 +252,18 @@ export function ProfileEditScreen() {
           <button
             type="button"
             onClick={handleSave}
-            disabled={!canSave}
+            disabled={!canSave || saving}
             style={{
               background: 'transparent',
               border: 0,
               fontSize: 14,
-              color: canSave ? 'var(--brand)' : 'var(--ink-4)',
+              color: canSave && !saving ? 'var(--brand)' : 'var(--ink-4)',
               fontWeight: 800,
               padding: 8,
-              cursor: canSave ? 'pointer' : 'default',
+              cursor: canSave && !saving ? 'pointer' : 'default',
               fontFamily: 'inherit',
             }}
-          >저장</button>
+          >{saving ? '저장 중' : '저장'}</button>
         </div>
       </div>
 

--- a/src/features/rooms/pages/Rooms.jsx
+++ b/src/features/rooms/pages/Rooms.jsx
@@ -6,7 +6,7 @@ import { CREATE_ROOM_DORMS, ROOM_SIZE_OPTIONS } from '../../checklist';
 import { findRooms, likeRoom, unlikeRoom, loadLikedRooms, loadMyChecklist, loadRoomRule, loadRecommendedRooms, loadMyRoom } from '../../../shared/api/home';
 import { getOrCreateDirectChatRoom, loadMyChatRooms, leaveChatRoom } from '../../../shared/api/chat';
 import { getCachedUserNo } from '../../../shared/api/auth';
-import { loadApplications, loadMyRoommates, deleteRoom } from '../../../shared/api/room';
+import { loadApplications, loadMyRoommates, deleteRoom, checkMyRoom } from '../../../shared/api/room';
 import { normalizeRoom as normalizeBackendRoom, roommateToMember } from '../roomData';
 
 // rooms.jsx — 방 찾기 (list), 방 상세 (detail w/ checklist), 내 방 (my room)
@@ -580,6 +580,7 @@ export function FindRoomScreen({ activeTab='find' }) {
   const [totalCount, setTotalCount] = React.useState(null);
   const [bookmarkedIds, setBookmarkedIds] = React.useState(new Set());
   const [recommendedCount, setRecommendedCount] = React.useState(null);
+  const [hasRoom, setHasRoom] = React.useState(null);
   const loadMoreRef = React.useRef(null);
   const searchVersionRef = React.useRef(0);
 
@@ -611,6 +612,14 @@ export function FindRoomScreen({ activeTab='find' }) {
     loadRecommendedRooms()
       .then((res) => setRecommendedCount(res.hasChecklist ? res.items.length : -1))
       .catch(() => {});
+  }, []);
+
+  React.useEffect(() => {
+    let mounted = true;
+    checkMyRoom()
+      .then((res) => { if (mounted) setHasRoom(res); })
+      .catch(() => { if (mounted) setHasRoom({ isExist: true }); });
+    return () => { mounted = false; };
   }, []);
 
   React.useEffect(() => {
@@ -797,16 +806,18 @@ export function FindRoomScreen({ activeTab='find' }) {
       </div>
 
       {/* FAB */}
-      <button onClick={() => navigate('/rooms/create/1')} style={{
-        position: 'absolute', bottom: 96, right: 18, zIndex: 5,
-        height: 52, padding: '0 18px', borderRadius: 26, border: 0,
-        background: 'var(--ink)', color: 'white', fontWeight: 600, fontSize: 14,
-        display: 'inline-flex', alignItems: 'center', gap: 6,
-        boxShadow: '0 8px 24px rgba(0,0,0,0.18)',
-        cursor: 'pointer',
-      }}>
-        <Icon.plus size={18}/> 모집방 만들기
-      </button>
+      {hasRoom && !hasRoom.isExist && (
+        <button onClick={() => navigate('/rooms/create/1')} style={{
+          position: 'absolute', bottom: 96, right: 18, zIndex: 5,
+          height: 52, padding: '0 18px', borderRadius: 26, border: 0,
+          background: 'var(--ink)', color: 'white', fontWeight: 600, fontSize: 14,
+          display: 'inline-flex', alignItems: 'center', gap: 6,
+          boxShadow: '0 8px 24px rgba(0,0,0,0.18)',
+          cursor: 'pointer',
+        }}>
+          <Icon.plus size={18}/> 모집방 만들기
+        </button>
+      )}
 
       <TabBar active={activeTab} />
     </div>

--- a/src/features/rooms/pages/Rooms.jsx
+++ b/src/features/rooms/pages/Rooms.jsx
@@ -6,7 +6,7 @@ import { CREATE_ROOM_DORMS, ROOM_SIZE_OPTIONS } from '../../checklist';
 import { findRooms, likeRoom, unlikeRoom, loadLikedRooms, loadMyChecklist, loadRoomRule, loadRecommendedRooms, loadMyRoom } from '../../../shared/api/home';
 import { getOrCreateDirectChatRoom, loadMyChatRooms, leaveChatRoom } from '../../../shared/api/chat';
 import { getCachedUserNo } from '../../../shared/api/auth';
-import { loadApplications, loadMyRoommates, deleteRoom, checkMyRoom } from '../../../shared/api/room';
+import { loadApplications, loadMyRoommates, deleteRoom, checkMyRoom, confirmRoomAssignment } from '../../../shared/api/room';
 import { normalizeRoom as normalizeBackendRoom, roommateToMember } from '../roomData';
 
 // rooms.jsx — 방 찾기 (list), 방 상세 (detail w/ checklist), 내 방 (my room)
@@ -1102,6 +1102,11 @@ export function MyRoomScreen({ activeTab='myroom' }) {
   const [error, setError] = React.useState('');
   const [groupChatRoomNo, setGroupChatRoomNo] = React.useState(null);
   const [leaving, setLeaving] = React.useState(false);
+  const [confirming, setConfirming] = React.useState(false);
+
+  const refreshRoom = () => loadMyRoom().then((roomData) => {
+    setRoom(roomData?.roomNo ? normalizeBackendRoom(roomData) : null);
+  });
 
   React.useEffect(() => {
     let mounted = true;
@@ -1160,6 +1165,16 @@ export function MyRoomScreen({ activeTab='myroom' }) {
   const canLeaveRoom = !isHost || currentMembers <= 1;
   const openSeats = Math.max(0, roomCapacity - currentMembers);
   const isRoomFull = currentMembers >= roomCapacity;
+  const canConfirmRoom = isHost && room?.roomStatus === 'CONFIRM_PENDING';
+
+  const confirmRoom = () => {
+    if (!canConfirmRoom || confirming) return;
+    setConfirming(true);
+    confirmRoomAssignment(room.roomNo)
+      .then(() => refreshRoom())
+      .catch((e) => alert(e?.message || '방 확정에 실패했어요.'))
+      .finally(() => setConfirming(false));
+  };
 
   const leaveRoom = () => {
     if (!canLeaveRoom || leaving) return;
@@ -1250,6 +1265,23 @@ export function MyRoomScreen({ activeTab='myroom' }) {
             </div>
           </div>
         </div>
+
+        {canConfirmRoom && (
+          <div style={{ margin: '0 16px 16px' }} className="card">
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: 4 }}>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 14, fontWeight: 700 }}>정원이 모두 찼어요</div>
+                <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 2 }}>방을 확정하면 더 이상 신청을 받지 않아요.</div>
+              </div>
+              <button
+                onClick={confirmRoom}
+                disabled={confirming}
+                className="btn full"
+                style={{ width: 'auto', padding: '0 16px', height: 44, opacity: confirming ? 0.6 : 1 }}
+              >{confirming ? '확정 중...' : '방 확정하기'}</button>
+            </div>
+          </div>
+        )}
 
         {/* Quick actions — pill list */}
         <div style={{ padding: '0 16px', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>

--- a/src/features/rooms/roomData.js
+++ b/src/features/rooms/roomData.js
@@ -290,6 +290,15 @@ export function checklistFormToRoomRuleRequest(form, room) {
   };
 }
 
+export function checklistFormToUserChecklistRequest(form) {
+  const { roomType, capacity, residencePeriod, ...userChecklistRequest } = checklistFormToRoomRuleRequest(form, {
+    roomType: null,
+    capacity: null,
+    residencePeriod: null,
+  });
+  return userChecklistRequest;
+}
+
 export function createRoomDraftToRequest(draft, checklistForm = defaultRoomChecklistForm) {
   const roomType = ROOM_TYPE_BY_LABEL[draft.dorm] || draft.roomType || 'TYPE_2';
   const capacity = Number.parseInt(draft.roomSize || draft.capacity, 10) || 4;

--- a/src/features/rooms/roomData.js
+++ b/src/features/rooms/roomData.js
@@ -19,6 +19,12 @@ export const RESIDENCE_PERIOD_LABELS = {
 
 export const residencePeriodLabel = (period) => RESIDENCE_PERIOD_LABELS[period] || period || '';
 
+export const roomStatusLabel = (roomStatus) => {
+  if (roomStatus === 'COMPLETED') return '모집 완료';
+  if (roomStatus === 'CONFIRM_PENDING') return '확정 대기';
+  return '모집중';
+};
+
 export const CHECKLIST_VALUE_LABELS = {
   FLEXIBLE: '유동적',
   FIXED: '고정적',

--- a/src/features/rooms/roomData.test.js
+++ b/src/features/rooms/roomData.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   checklistFormToRoomRuleRequest,
+  checklistFormToUserChecklistRequest,
   createRoomDraftToRequest,
   normalizeRoom,
   roomRuleToChecklist,
@@ -208,5 +209,42 @@ describe('roomData helpers', () => {
     expect(request.rule).not.toHaveProperty('roomType');
     expect(request.rule).not.toHaveProperty('capacity');
     expect(request.rule).not.toHaveProperty('residencePeriod');
+  });
+
+  it('checklistFormToUserChecklistRequest는 방 정보 없이 개인 체크리스트 요청을 만든다', () => {
+    const request = checklistFormToUserChecklistRequest({
+      sleep: { start: 23, end: 1 },
+      wake: { start: 7, end: 9 },
+      dryer: null,
+      homing: '고정적',
+      cleaning: '주기적',
+      call: '가능',
+      dim: '어두움',
+      sleepHabit: '약함',
+      snore: '약함~없음',
+      shower: '저녁',
+      eating: '가능+환기필수',
+      lightsOut: '시간 지정',
+      lightsOutHour: 23,
+      visitHome: '2주',
+      smoke: '비흡연',
+      fridge: '협의 후 결정',
+      alarm: '진동',
+      earphone: '항상',
+      skinCare: '유동적',
+      hot: '중간',
+      cold: '중간',
+      study: '기숙사 안',
+      trash: '개별',
+    });
+
+    expect(request).toMatchObject({
+      bedtime: '23:00-01:00',
+      wakeUp: '07:00-09:00',
+      returnHome: 'FIXED',
+    });
+    expect(request).not.toHaveProperty('roomType');
+    expect(request).not.toHaveProperty('capacity');
+    expect(request).not.toHaveProperty('residencePeriod');
   });
 });

--- a/src/shared/api/auth.js
+++ b/src/shared/api/auth.js
@@ -98,6 +98,15 @@ export async function reissueToken() {
   await apiRequest('/api/token/reissue', { method: 'POST' });
 }
 
+export async function updateUserProfile(request) {
+  const profile = await apiRequest('/api/users/profile', {
+    method: 'PATCH',
+    body: request,
+  });
+  cacheProfile(profile);
+  return profile;
+}
+
 export async function getMe({ retry = true } = {}) {
   try {
     const profile = await apiRequest('/api/users/profile/me');

--- a/src/shared/api/home.js
+++ b/src/shared/api/home.js
@@ -60,3 +60,7 @@ export function unlikeRoom(roomNo) {
 export function loadRecommendedRooms() {
   return apiRequestWithAuth('/api/rooms/recommended');
 }
+
+export function loadMyAppliedRooms() {
+  return apiRequestWithAuth('/api/rooms/me/applied');
+}

--- a/src/shared/api/home.js
+++ b/src/shared/api/home.js
@@ -37,6 +37,14 @@ export function loadMyChecklist() {
   return apiRequestWithAuth('/api/users/me/checklist');
 }
 
+export function createUserChecklist(request) {
+  return apiRequestWithAuth('/api/users/me/checklist', { method: 'POST', body: request });
+}
+
+export function updateUserChecklist(request) {
+  return apiRequestWithAuth('/api/users/me/checklist', { method: 'PUT', body: request });
+}
+
 export function loadLikedRooms() {
   return apiRequestWithAuth('/api/rooms/me/liked');
 }

--- a/src/shared/api/room.js
+++ b/src/shared/api/room.js
@@ -67,6 +67,12 @@ export function kickRoommate(roomNo, kickedUserNo) {
   });
 }
 
+export function confirmRoomAssignment(roomNo) {
+  return client.apiRequestWithAuth(`/api/rooms/me/confirm?roomNo=${encodeURIComponent(roomNo)}`, {
+    method: 'POST',
+  });
+}
+
 export function updateRoomTitle(roomNo, request) {
   return client.apiRequestWithAuth(`/api/rooms/me/title?roomNo=${encodeURIComponent(roomNo)}`, {
     method: 'PUT',

--- a/src/shared/api/room.js
+++ b/src/shared/api/room.js
@@ -57,6 +57,10 @@ export function cancelRoomApplication(roomNo) {
   });
 }
 
+export function checkMyRoom() {
+  return client.apiRequestWithAuth('/api/rooms/me/exists');
+}
+
 export function updateRoomTitle(roomNo, request) {
   return client.apiRequestWithAuth(`/api/rooms/me/title?roomNo=${encodeURIComponent(roomNo)}`, {
     method: 'PUT',

--- a/src/shared/api/room.js
+++ b/src/shared/api/room.js
@@ -61,6 +61,12 @@ export function checkMyRoom() {
   return client.apiRequestWithAuth('/api/rooms/me/exists');
 }
 
+export function kickRoommate(roomNo, kickedUserNo) {
+  return client.apiRequestWithAuth(`/api/rooms/${roomNo}/members/${kickedUserNo}`, {
+    method: 'DELETE',
+  });
+}
+
 export function updateRoomTitle(roomNo, request) {
   return client.apiRequestWithAuth(`/api/rooms/me/title?roomNo=${encodeURIComponent(roomNo)}`, {
     method: 'PUT',

--- a/src/shared/api/room.js
+++ b/src/shared/api/room.js
@@ -51,6 +51,12 @@ export function loadMyRoommates() {
   return client.apiRequestWithAuth('/api/rooms/me/roommates');
 }
 
+export function cancelRoomApplication(roomNo) {
+  return client.apiRequestWithAuth(`/api/rooms/${roomNo}/request`, {
+    method: 'DELETE',
+  });
+}
+
 export function updateRoomTitle(roomNo, request) {
   return client.apiRequestWithAuth(`/api/rooms/me/title?roomNo=${encodeURIComponent(roomNo)}`, {
     method: 'PUT',


### PR DESCRIPTION
# 📝 Pull Request Template

## 📌 제목
> **[FIX] 마이페이지·방 관리 잔여 API 연동 — 프로필/체크리스트/신청내역/북마크/방만들기 게이팅/내보내기/방확정**

---

## 📢 요약

백엔드에는 이미 구현돼 있지만 프론트엔드에서 전혀 호출되지 않거나 화면이 하드코딩 mock으로 남아있던 7개 지점을 한 브랜치에서 연동했습니다.

🔗 **연관 이슈**: Resolves #21

---

## 🚀 PR 유형
> **해당하는 항목에 체크해주세요.**

- [ ] ✨ 새로운 기능 추가
- [x] 🐛 버그 수정
- [ ] 🎨 CSS/UI 디자인 변경
- [ ] 🔧 코드에 영향 없는 변경(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 🔨 코드 리팩토링
- [x] 🧪 테스트 추가 또는 리팩토링
- [ ] 🏗️ 빌드 및 패키지 매니저 수정
- [ ] 📂 파일 또는 폴더명 수정
- [ ] 🗑️ 파일 또는 폴더 삭제

---

## 📜 상세 설명

### 0. (사전 발견) main 빌드 깨짐 핫픽스
채팅(PR #18)·알림(PR #20) 병합 과정에서 `Details.jsx`에 `logout`/`loadMyRoom`/`ChatComposer`가 두 줄로 중복 import되어 `main`이 빌드조차 안 되던 상태였습니다. 작업 착수 전 정리했습니다.

### 1. 프로필 수정 서버 연동
`ProfileEditScreen`이 `localStorage`에만 저장하고 서버엔 반영되지 않던 문제 수정. `PATCH /api/users/profile` 연동, 성공 시 응답으로 캐시 갱신.

### 2. 개인 체크리스트 조회/저장 연동
`ChecklistEditScreen`(personal 모드)이 서버 데이터를 불러오지도 저장하지도 않던 문제 수정. `GET /api/users/me/checklist`로 기존 값을 불러와 폼에 채우고, 있으면 `PUT`, 없으면 `POST`로 저장. 기존 방 규칙 매퍼(`checklistFormToRoomRuleRequest`)를 재사용해 `checklistFormToUserChecklistRequest` 추가.

### 3. 신청 내역 화면 mock 제거
`MyApplicationsScreen`이 하드코딩 배열을 쓰던 것을 `GET /api/rooms/me/applied`로 교체. 백엔드 응답엔 신청 수락/거절 여부가 없어(방 자체 모집 상태만 제공) 대기중/수락됨/거절됨 탭 대신 방 상태(모집중/확정대기/모집완료)로 단순화했고, 수락/거절 필드 추가를 요청하는 후속 이슈를 BE 저장소에 별도로 남겼습니다(dorumdorum/be#117). 취소는 `DELETE /api/rooms/{roomNo}/request` 연동.

### 4. 북마크 화면 mock 제거
`BookmarksScreen`을 이미 존재하던 `loadLikedRooms`/`unlikeRoom`(방 목록 하트 토글에 쓰이던 함수)으로 교체. 백엔드에 좋아요 시점 데이터가 없어 "저장일" 표시는 제거.

### 5. "모집방 만들기" 버튼 게이팅
`FindRoomScreen`의 FAB이 조건 없이 항상 노출되던 버그 수정(이슈 #12에서 다뤘던 문제가 리디자인 이후 재발). `GET /api/rooms/me/exists`로 이미 방이 있는지 확인해 있으면 숨김. 확인 전/실패 시엔 안전하게 숨김 처리(fail-closed).

### 6. 룸메이트 내보내기 UI
방장에게만 룸메이트 카드에 내보내기 버튼을 노출하고, 확인 후 `DELETE /api/rooms/{roomNo}/members/{kickedUserNo}` 연동. 이슈 #12에서 요청됐던 기능인데 리디자인 이후 UI 자체가 남아있지 않아 새로 구현했습니다.

### 7. 방 확정하기 버튼
정원이 다 찬(`CONFIRM_PENDING`) 방의 방장에게 "방 확정하기" 버튼 노출, `POST /api/rooms/me/confirm` 연동. 성공 시 내 방 정보를 다시 불러와 상태 갱신.

---

## ✅ PR 체크리스트
> **PR이 다음 요구 사항을 충족하는지 확인해주세요.**

- [x] 🔹 커밋 메시지 컨벤션을 준수했습니다. (항목별로 커밋 분리)
- [x] 🔹 변경 사항에 대한 테스트를 수행했습니다. (`npm run build`/`npm run test` 매 커밋마다 통과, Playwright로 각 화면을 실제 API 응답 형태로 mocking해 정상/실패/권한 케이스 클릭스루 검증)
- [ ] 🔹 관련 문서를 업데이트했습니다. (해당 없음)

---

## 📜 기타
> **리뷰어가 알면 좋을 추가 사항을 적어주세요.**

- 신청 내역 화면의 상태 탭 단순화(3번)와 북마크의 저장일 제거(4번)는 백엔드 응답에 해당 데이터가 없어서 내린 판단입니다. 필요하면 BE 쪽 필드 추가 논의 후 되돌릴 수 있습니다.
- 룸메이트 내보내기(6번) 경로는 `DELETE /api/rooms/{roomNo}/members/{kickedUserNo}`로, 과거 이슈 #12 본문에 적혀있던 `/roommates/{targetUserNo}`와 다릅니다 — BE 소스(`KickRoommateApiSpec.java`)를 직접 확인해 현재 실제 구현 경로를 사용했습니다.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CceiMekWiUvghg4dfkfYbp)_