### PR TITLE
feat: 누락 API 프론트 연동

### DIFF
--- a/src/features/checklist/pages/Details.jsx
+++ b/src/features/checklist/pages/Details.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { Icon, StatusBar, Avatar, goBack } from '../../../shared/components';
-import { logout as logoutUser, getCachedUserNo, getMe } from '../../../shared/api/auth';
+import { logout as logoutUser, deleteAccount, getCachedUserNo, getMe } from '../../../shared/api/auth';
 import {
   loadMyRoom, loadNotices, loadNotifications, markAllNotificationsRead, markNotificationRead, registerNotificationDevice,
   loadMyChecklist, createUserChecklist, updateUserChecklist,
   loadMyAppliedRooms, loadLikedRooms, unlikeRoom,
+  loadNoticeDetail, loadNotificationSettings, updateNotificationSettings,
 } from '../../../shared/api/home';
+import { createSupportInquiry } from '../../../shared/api/support';
 import { submitRoomApplication, approveApplication, rejectApplication, loadMyRoomRule, updateMyRoomRule, createRoom, cancelRoomApplication } from '../../../shared/api/room';
 import { ChatMessageItem, ChatComposer } from '../../chat';
 import { getOrCreateDirectChatRoom, loadChatMessages, markChatRoomRead, leaveChatRoom } from '../../../shared/api/chat';
@@ -1222,13 +1224,24 @@ export function NoticeDetailScreen() {
   React.useEffect(() => {
     if (notice || !id) return undefined;
     let mounted = true;
-    loadNotices()
-      .then((list) => {
+    loadNoticeDetail(id)
+      .then((detail) => {
         if (!mounted) return;
-        const found = (Array.isArray(list) ? list : []).map(normalizeNotice).find((item) => String(item.noticeNo) === String(id));
-        setNotice(found || null);
+        if (!detail || typeof detail !== 'object') {
+          throw new TypeError('Notice detail response must be an object');
+        }
+        setNotice(detail ? normalizeNotice(detail) : null);
       })
-      .finally(() => { if (mounted) setLoading(false); });
+      .catch(() => loadNotices().then((list) => {
+        if (!mounted) return;
+        const found = (Array.isArray(list) ? list : []).map(normalizeNotice).find((item) => String(item.noticeNo || item.id) === String(id));
+        setNotice(found || null);
+      }).catch(() => {
+        if (mounted) setNotice(null);
+      }))
+      .finally(() => {
+        if (mounted) setLoading(false);
+      })
     return () => { mounted = false; };
   }, [id, notice]);
 
@@ -1492,7 +1505,6 @@ export function NotificationsScreen() {
 export function NotificationSettingsScreen() {
   const navigate = useNavigate();
   const [enabled, setEnabled] = React.useState(true);
-  const settingsApiReady = false;
   const [settings, setSettings] = React.useState({
     applicants: true,
     applicantResult: true,
@@ -1500,8 +1512,77 @@ export function NotificationSettingsScreen() {
     notice: true,
     schedule: false,
   });
+  const [loading, setLoading] = React.useState(true);
+  const [saving, setSaving] = React.useState(false);
+  const [error, setError] = React.useState('');
 
-  const set = (key) => setSettings((prev) => ({ ...prev, [key]: !prev[key] }));
+  React.useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    setError('');
+    loadNotificationSettings()
+      .then((next) => {
+        if (!mounted) return;
+        setEnabled(Boolean(next?.enabled));
+        setSettings({
+          applicants: Boolean(next?.applicants),
+          applicantResult: Boolean(next?.applicantResult),
+          chat: Boolean(next?.chat),
+          notice: Boolean(next?.notice),
+          schedule: Boolean(next?.schedule),
+        });
+      })
+      .catch((e) => {
+        if (mounted) setError('알림 설정을 불러오지 못했어요.');
+      })
+      .finally(() => { if (mounted) setLoading(false); });
+    return () => { mounted = false; };
+  }, []);
+
+  const saveSettings = (nextEnabled, nextSettings) => {
+    setSaving(true);
+    setError('');
+    return updateNotificationSettings({ enabled: nextEnabled, ...nextSettings })
+      .then((saved) => {
+        setEnabled(Boolean(saved?.enabled));
+        setSettings({
+          applicants: Boolean(saved?.applicants),
+          applicantResult: Boolean(saved?.applicantResult),
+          chat: Boolean(saved?.chat),
+          notice: Boolean(saved?.notice),
+          schedule: Boolean(saved?.schedule),
+        });
+      })
+      .catch((e) => {
+        setError('알림 설정을 저장하지 못했어요.');
+        throw e;
+      })
+      .finally(() => setSaving(false));
+  };
+
+  const set = (key) => {
+    if (saving || loading) return;
+    const previousEnabled = enabled;
+    const previousSettings = settings;
+    const nextSettings = { ...settings, [key]: !settings[key] };
+    setSettings(nextSettings);
+    saveSettings(enabled, nextSettings).catch(() => {
+      setEnabled(previousEnabled);
+      setSettings(previousSettings);
+    });
+  };
+
+  const toggleEnabled = () => {
+    if (saving || loading) return;
+    const previousEnabled = enabled;
+    const previousSettings = settings;
+    const nextEnabled = !enabled;
+    setEnabled(nextEnabled);
+    saveSettings(nextEnabled, settings).catch(() => {
+      setEnabled(previousEnabled);
+      setSettings(previousSettings);
+    });
+  };
 
   const Toggle = ({ checked, onClick, disabled = false }) => (
     <button
@@ -1546,7 +1627,7 @@ export function NotificationSettingsScreen() {
         gap: 12,
         padding: '14px 16px',
         borderBottom: '1px solid var(--line)',
-        opacity: enabled && settingsApiReady ? 1 : 0.55,
+        opacity: enabled && !loading ? 1 : 0.55,
       }}>
         <div style={{
           width: 38,
@@ -1565,7 +1646,7 @@ export function NotificationSettingsScreen() {
           <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--ink)' }}>{title}</div>
           <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 3, lineHeight: 1.4 }}>{desc}</div>
         </div>
-        <Toggle checked={settings[valueKey] && enabled} disabled={!enabled || !settingsApiReady} onClick={() => set(valueKey)} />
+        <Toggle checked={settings[valueKey] && enabled} disabled={!enabled || loading || saving} onClick={() => set(valueKey)} />
       </div>
     );
   };
@@ -1596,7 +1677,7 @@ export function NotificationSettingsScreen() {
             필요한 알림만 받을 수 있어요
           </div>
           <div style={{ fontSize: 13, color: 'var(--ink-3)', marginTop: 6, lineHeight: 1.5 }}>
-            알림 설정 저장 API가 준비되면 방 신청, 채팅, 기숙사 공지 알림을 따로 조절할 수 있어요.
+            방 신청, 채팅, 기숙사 공지 알림을 따로 조절할 수 있어요.
           </div>
         </div>
 
@@ -1621,13 +1702,15 @@ export function NotificationSettingsScreen() {
                 모든 앱 알림을 한 번에 켜고 꺼요
               </div>
             </div>
-            <Toggle checked={enabled} disabled={!settingsApiReady} onClick={() => setEnabled(!enabled)} />
+            <Toggle checked={enabled} disabled={loading || saving} onClick={toggleEnabled} />
           </div>
         </div>
 
-        <div style={{ margin: '12px 16px 0', background: 'var(--brand-soft)', borderRadius: 14, padding: 14, color: 'var(--brand-deep)', fontSize: 12, lineHeight: 1.5, fontWeight: 700 }}>
-          현재 백엔드에 알림 설정 저장 API가 없어 설정 변경은 아직 지원하지 않아요.
-        </div>
+        {(loading || saving || error) && (
+          <div style={{ margin: '12px 16px 0', background: error ? '#FFF4F3' : 'var(--brand-soft)', borderRadius: 14, padding: 14, color: error ? 'var(--danger)' : 'var(--brand-deep)', fontSize: 12, lineHeight: 1.5, fontWeight: 700 }}>
+            {error || (saving ? '알림 설정을 저장하고 있어요.' : '알림 설정을 불러오고 있어요.')}
+          </div>
+        )}
 
         <Section title="방과 신청">
           <SettingRow icon="user" title="새 신청자" desc="내 모집방에 누군가 신청하면 알려줘요" valueKey="applicants" />
@@ -1834,9 +1917,20 @@ export function DeleteAccountScreen() {
   const [reason, setReason] = React.useState('');
   const [confirmText, setConfirmText] = React.useState('');
   const [confirmed, setConfirmed] = React.useState(false);
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState('');
   const reasons = ['졸업했어요', '서비스를 자주 쓰지 않아요', '원하는 기능이 부족해요', '개인정보가 걱정돼요', '다른 이유'];
-  const deleteApiReady = false;
-  const canDelete = deleteApiReady && reason && confirmed && confirmText.trim() === '탈퇴';
+  const canDelete = Boolean(reason && confirmed && confirmText.trim() === '탈퇴' && !submitting);
+
+  const submitDelete = () => {
+    if (!canDelete) return;
+    setSubmitting(true);
+    setError('');
+    deleteAccount(reason)
+      .then(() => navigate('/login', { replace: true }))
+      .catch((e) => setError(e?.message || '계정 탈퇴에 실패했어요.'))
+      .finally(() => setSubmitting(false));
+  };
 
   return (
     <div className="screen">
@@ -1850,7 +1944,7 @@ export function DeleteAccountScreen() {
             <br />확인해주세요
           </div>
           <div style={{ fontSize: 13, color: 'var(--ink-3)', marginTop: 6, lineHeight: 1.5 }}>
-            현재 백엔드에 계정 탈퇴 API가 없어 앱에서 직접 탈퇴는 아직 지원하지 않아요.
+            탈퇴하면 계정과 이용 기록 일부가 삭제되거나 익명 처리돼요.
           </div>
         </div>
 
@@ -1923,9 +2017,11 @@ export function DeleteAccountScreen() {
             탈퇴 후 계정과 이용 기록을 복구할 수 없다는 점을 확인했어요.
           </span>
         </label>
-        <div style={{ marginTop: 14, background: 'var(--brand-soft)', borderRadius: 14, padding: 14, color: 'var(--brand-deep)', fontSize: 12, lineHeight: 1.5, fontWeight: 700 }}>
-          계정 탈퇴가 필요하면 고객 문의로 요청해주세요. API가 추가되면 이 화면에서 직접 처리할 수 있게 연결할 예정이에요.
-        </div>
+        {error && (
+          <div style={{ marginTop: 14, background: '#FFF4F3', borderRadius: 14, padding: 14, color: 'var(--danger)', fontSize: 12, lineHeight: 1.5, fontWeight: 700 }}>
+            {error}
+          </div>
+        )}
         <div style={{ height: 28 }} />
       </div>
 
@@ -1934,7 +2030,7 @@ export function DeleteAccountScreen() {
         <button
           type="button"
           disabled={!canDelete}
-          onClick={undefined}
+          onClick={submitDelete}
           className="btn full"
           style={{
             flex: 1,
@@ -1943,7 +2039,7 @@ export function DeleteAccountScreen() {
             color: canDelete ? 'white' : 'var(--ink-4)',
             cursor: canDelete ? 'pointer' : 'default',
           }}
-        >탈퇴 API 준비 중</button>
+        >{submitting ? '탈퇴 처리 중...' : '계정 탈퇴'}</button>
       </div>
     </div>
   );
@@ -1954,9 +2050,27 @@ export function SupportScreen() {
   const navigate = useNavigate();
   const [category, setCategory] = React.useState('앱 이용');
   const [message, setMessage] = React.useState('');
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState('');
   const maxLength = 500;
-  const supportApiReady = false;
   const categories = ['앱 이용', '매칭/신청', '계정/인증', '오류 및 사용자 신고'];
+  const categoryMap = {
+    '앱 이용': 'APP_USAGE',
+    '매칭/신청': 'MATCHING',
+    '계정/인증': 'ACCOUNT',
+    '오류 및 사용자 신고': 'BUG_REPORT',
+  };
+  const canSubmit = Boolean(message.trim() && !submitting);
+
+  const submitInquiry = () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError('');
+    createSupportInquiry({ category: categoryMap[category] || 'ETC', message: message.trim() })
+      .then(() => navigate('/me'))
+      .catch((e) => setError(e?.message || '문의를 접수하지 못했어요.'))
+      .finally(() => setSubmitting(false));
+  };
 
   return (
     <div className="screen">
@@ -1973,7 +2087,7 @@ export function SupportScreen() {
             무엇을 도와드릴까요?
           </div>
           <div style={{ fontSize: 13, color: 'var(--ink-3)', marginTop: 6, lineHeight: 1.5 }}>
-            현재 문의 접수 API가 없어 안내 정보만 제공해요.
+            문의 내용을 남겨주시면 확인 후 답변드릴게요.
           </div>
         </div>
 
@@ -2043,20 +2157,22 @@ export function SupportScreen() {
           />
         </div>
 
-        <div style={{ background: 'var(--brand-soft)', borderRadius: 14, padding: 14, color: 'var(--brand-deep)', fontSize: 12, lineHeight: 1.5, fontWeight: 700 }}>
-          문의 접수 API가 준비되면 이 화면에서 바로 문의를 보낼 수 있어요.
-        </div>
+        {error && (
+          <div style={{ background: '#FFF4F3', borderRadius: 14, padding: 14, color: 'var(--danger)', fontSize: 12, lineHeight: 1.5, fontWeight: 700 }}>
+            {error}
+          </div>
+        )}
 
       </div>
 
       <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, padding: '14px 16px 30px', background: 'var(--surface)', borderTop: '1px solid var(--line)' }}>
         <button
-          onClick={() => navigate('/me')}
-          disabled={!supportApiReady}
+          onClick={submitInquiry}
+          disabled={!canSubmit}
           className="btn full"
-          style={{ height: 52, opacity: supportApiReady && message.trim() ? 1 : 0.55, cursor: supportApiReady ? 'pointer' : 'not-allowed' }}
+          style={{ height: 52, opacity: canSubmit ? 1 : 0.55, cursor: canSubmit ? 'pointer' : 'not-allowed' }}
         >
-          문의 API 준비 중
+          {submitting ? '문의 접수 중...' : '문의 보내기'}
         </button>
       </div>
     </div>

--- a/src/features/members/pages/Members.jsx
+++ b/src/features/members/pages/Members.jsx
@@ -4,7 +4,7 @@ import { Icon, Avatar, StatusBar, goBack } from '../../../shared/components';
 import { loadUserProfile } from '../../../shared/api/auth';
 import { loadMyRoom, loadUserChecklist } from '../../../shared/api/home';
 import { getOrCreateDirectChatRoom, loadMyChatRooms } from '../../../shared/api/chat';
-import { loadMyRoommates, kickRoommate } from '../../../shared/api/room';
+import { loadMyRoommates, loadRoommateHistory, kickRoommate } from '../../../shared/api/room';
 import { normalizeRoom, roommateToMember, roomRuleToChecklist } from '../../rooms/roomData';
 
 // members.jsx — 룸메이트 멤버 화면 (방장 시점)
@@ -29,6 +29,23 @@ async function enrichMember(member) {
     checklist,
   };
 }
+
+const historyToMember = (history) => ({
+  id: history.historyNo || `${history.roomNo}-${history.roommateUserNo}`,
+  userNo: history.roommateUserNo,
+  name: history.nickname || history.name,
+  realName: history.name,
+  studentId: history.studentNo,
+  dept: [history.major, history.studentYear ? `${history.studentYear}학번` : null].filter(Boolean).join(' '),
+  role: history.relation === 'CURRENT' ? '현재' : '과거',
+  confirmStatus: history.relation === 'CURRENT' ? '입주 중' : '함께 지냄',
+  roomTitle: history.roomTitle,
+  roomType: history.roomType,
+  capacity: history.capacity,
+  startedAt: history.startedAt,
+  endedAt: history.endedAt,
+  checklist: [],
+});
 
 export function MemberCard({ m, defaultOpen = false, onOpenChat, onKick }) {
   const [open, setOpen] = React.useState(defaultOpen);
@@ -314,12 +331,12 @@ export function RoommateHistoryScreen() {
     setError('');
     Promise.all([
       loadMyRoom().catch(() => null),
-      loadMyRoommates(),
+      loadRoommateHistory(),
     ])
       .then(([roomData, roommateList]) => {
         if (!mounted) return;
         setRoom(roomData?.roomNo ? normalizeRoom(roomData) : null);
-        const baseMembers = Array.isArray(roommateList) ? roommateList.map(roommateToMember) : [];
+        const baseMembers = Array.isArray(roommateList) ? roommateList.map(historyToMember) : [];
         setRoommates(baseMembers);
         Promise.all(baseMembers.map(enrichMember))
           .then((nextMembers) => { if (mounted) setRoommates(nextMembers); });
@@ -329,7 +346,7 @@ export function RoommateHistoryScreen() {
     return () => { mounted = false; };
   }, []);
 
-  const roomLabel = room ? [room.dorm, room.size].filter(Boolean).join(' · ') : '현재 방 정보';
+  const roomLabel = room ? [room.dorm, room.size].filter(Boolean).join(' · ') : '방 정보';
 
   return (
     <div className="screen">
@@ -342,8 +359,8 @@ export function RoommateHistoryScreen() {
 
       <div className="scroll" style={{ padding: '4px 16px 28px' }}>
         <div style={{ padding: '4px 4px 16px' }}>
-          <div style={{ fontSize: 22, fontWeight: 800, letterSpacing: '-0.4px' }}>함께 지내는 룸메이트</div>
-          <div style={{ fontSize: 13, color: 'var(--ink-3)', marginTop: 5, lineHeight: 1.45 }}>현재 같은 방에 입주한 룸메이트 목록이에요.</div>
+          <div style={{ fontSize: 22, fontWeight: 800, letterSpacing: '-0.4px' }}>룸메이트 기록</div>
+          <div style={{ fontSize: 13, color: 'var(--ink-3)', marginTop: 5, lineHeight: 1.45 }}>현재와 과거에 함께 지낸 룸메이트를 확인해요.</div>
         </div>
 
         <div className="card" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', padding: 4, marginBottom: 16 }}>
@@ -376,6 +393,7 @@ export function RoommateHistoryScreen() {
                   </div>
                   <div style={{ fontSize: 12, color: 'var(--ink-2)', marginTop: 5, fontWeight: 600 }}>{[mate.realName, mate.studentId].filter(Boolean).join(' · ') || '-'}</div>
                   <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 3 }}>{mate.dept}</div>
+                  {mate.roomTitle && <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 3 }}>{mate.roomTitle}</div>}
                 </div>
               </div>
 
@@ -386,19 +404,13 @@ export function RoommateHistoryScreen() {
                 </div>
                 <div>
                   <div style={{ fontSize: 11, color: 'var(--ink-3)', fontWeight: 700 }}>방 정보</div>
-                  <div style={{ fontSize: 13, color: 'var(--ink)', fontWeight: 800, marginTop: 4 }}>{roomLabel}</div>
+                  <div style={{ fontSize: 13, color: 'var(--ink)', fontWeight: 800, marginTop: 4 }}>{mate.roomTitle || roomLabel}</div>
                 </div>
               </div>
             </div>
           ))}
         </div>
 
-        <div style={{ marginTop: 14, background: 'var(--brand-soft)', borderRadius: 14, padding: 14, display: 'flex', alignItems: 'flex-start', gap: 10, color: 'var(--brand-deep)' }}>
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" style={{ marginTop: 1, flexShrink: 0 }}>
-            <path d="M12 2l9 4v6c0 5-3.5 9.5-9 10-5.5-.5-9-5-9-10V6l9-4z" stroke="currentColor" strokeWidth="1.8" />
-          </svg>
-          <div style={{ fontSize: 12, lineHeight: 1.5, fontWeight: 700 }}>과거 룸메이트 이력 API가 생기기 전까지 현재 방 룸메이트만 표시해요.</div>
-        </div>
       </div>
     </div>
   );

--- a/src/features/rooms/pages/Rooms.jsx
+++ b/src/features/rooms/pages/Rooms.jsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { Icon, TabBar, StatusBar, Avatar, MarqueeText, ClipText, goBack } from '../../../shared/components';
 import { MemberCard } from '../../members';
 import { CREATE_ROOM_DORMS, ROOM_SIZE_OPTIONS } from '../../checklist';
-import { findRooms, likeRoom, unlikeRoom, loadLikedRooms, loadMyChecklist, loadRoomRule, loadRecommendedRooms, loadMyRoom } from '../../../shared/api/home';
+import { findRooms, likeRoom, unlikeRoom, loadLikedRooms, loadMyChecklist, loadRoomRule, loadRecommendedRooms, loadMyRoom, loadRoomDetail } from '../../../shared/api/home';
 import { getOrCreateDirectChatRoom, loadMyChatRooms, leaveChatRoom } from '../../../shared/api/chat';
 import { getCachedUserNo } from '../../../shared/api/auth';
 import { loadApplications, loadMyRoommates, deleteRoom, checkMyRoom, confirmRoomAssignment } from '../../../shared/api/room';
@@ -561,6 +561,9 @@ const normalizeRoom = (r) => ({
   host: { name: r.hostNickname, major: r.hostMajor, studentYear: r.hostStudentYear },
   residencePeriod: r.residencePeriod,
   notes: r.notes ?? null,
+  liked: Boolean(r.liked),
+  appliedStatus: r.appliedStatus,
+  isMyRoom: Boolean(r.isMyRoom),
   checklist: [],
 });
 
@@ -572,6 +575,7 @@ export function FindRoomScreen({ activeTab='find' }) {
   const [roomTypeFilter, setRoomTypeFilter] = React.useState('전체');
   const [capacityFilter, setCapacityFilter] = React.useState('전체');
   const [periodFilter, setPeriodFilter] = React.useState('전체');
+  const [keyword, setKeyword] = React.useState('');
   const [rooms, setRooms] = React.useState([]);
   const [loading, setLoading] = React.useState(false);
   const [loadingMore, setLoadingMore] = React.useState(false);
@@ -631,12 +635,14 @@ export function FindRoomScreen({ activeTab='find' }) {
     setNextCursor(null);
     setHasNext(false);
     setTotalCount(null);
+    const trimmedKeyword = keyword.trim();
     findRooms({
       ...checklistFilter,
       sortType: toSortType(sortBy),
       roomType: roomTypeFilter === '전체' ? null : roomTypeFilter,
       capacity: capacityFilter === '전체' ? null : capacityFilter,
       residencePeriod: periodFilter === '전체' ? null : periodFilter,
+      keyword: trimmedKeyword || null,
     })
       .then((res) => {
         if (!mounted) return;
@@ -654,7 +660,7 @@ export function FindRoomScreen({ activeTab='find' }) {
       })
       .finally(() => { if (mounted) setLoading(false); });
     return () => { mounted = false; };
-  }, [capacityFilter, sortBy, roomTypeFilter, periodFilter]);
+  }, [capacityFilter, sortBy, roomTypeFilter, periodFilter, keyword]);
 
   React.useEffect(() => {
     const target = loadMoreRef.current;
@@ -666,12 +672,14 @@ export function FindRoomScreen({ activeTab='find' }) {
       if (!entry.isIntersecting || requested) return;
       requested = true;
       setLoadingMore(true);
+      const trimmedKeyword = keyword.trim();
       findRooms({
         ...checklistFilter,
         sortType: toSortType(sortBy),
         roomType: roomTypeFilter === '전체' ? null : roomTypeFilter,
         capacity: capacityFilter === '전체' ? null : capacityFilter,
         residencePeriod: periodFilter === '전체' ? null : periodFilter,
+        keyword: trimmedKeyword || null,
         cursor: nextCursor,
       })
         .then((res) => {
@@ -693,7 +701,7 @@ export function FindRoomScreen({ activeTab='find' }) {
 
     observer.observe(target);
     return () => observer.disconnect();
-  }, [capacityFilter, hasNext, loading, loadingMore, nextCursor, periodFilter, roomTypeFilter, sortBy]);
+  }, [capacityFilter, hasNext, keyword, loading, loadingMore, nextCursor, periodFilter, roomTypeFilter, sortBy]);
 
   const toggleRoomBookmark = (roomNo) => {
     const isBookmarked = bookmarkedIds.has(roomNo);
@@ -725,7 +733,23 @@ export function FindRoomScreen({ activeTab='find' }) {
         <div style={{ padding: '0 16px 12px' }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 10, background: 'var(--surface)', borderRadius: 14, padding: '12px 14px' }}>
             <Icon.search size={20} weight={1.8}/>
-            <span style={{ flex: 1, fontSize: 14, color: 'var(--ink-3)', minWidth: 0 }}>제목·방장 검색은 추후 지원 예정이에요</span>
+            <input
+              value={keyword}
+              onChange={(event) => setKeyword(event.target.value)}
+              placeholder="제목·방장 검색"
+              aria-label="방 제목 또는 방장 검색"
+              style={{
+                flex: 1,
+                minWidth: 0,
+                border: 0,
+                outline: 0,
+                background: 'transparent',
+                color: 'var(--ink)',
+                fontSize: 14,
+                fontWeight: 600,
+                fontFamily: 'inherit',
+              }}
+            />
             <button onClick={() => navigate('/rooms/find/filter', { state: { checklistFilter } })} aria-label="체크리스트로 찾기" style={{ background: 'transparent', border: 0, color: 'var(--ink-2)', padding: 0, display: 'flex', cursor: 'pointer' }}><Icon.filter/></button>
           </div>
         </div>
@@ -860,16 +884,44 @@ export function RoomDetailScreen() {
   const navigate = useNavigate();
   const { id = '1' } = useParams();
   const { state } = useLocation();
-  const room = state?.room || readCachedRoom(id) || ROOMS.find((item) => String(item.id) === String(id));
-  const isClosed = state?.closed ?? room?.recruiting === false;
-  const isApplied = state?.appliedStatus === 'waiting';
-  const isAccepted = state?.appliedStatus === 'accepted';
-
+  const initialRoom = state?.room || readCachedRoom(id) || ROOMS.find((item) => String(item.id) === String(id)) || null;
+  const [room, setRoom] = React.useState(initialRoom);
+  const [roomLoading, setRoomLoading] = React.useState(!initialRoom);
+  const [roomError, setRoomError] = React.useState('');
   const [bookmarked, setBookmarked] = React.useState(false);
   const [checklist, setChecklist] = React.useState([]);
   const [checklistLoading, setChecklistLoading] = React.useState(true);
   const [checklistError, setChecklistError] = React.useState(false);
   const [isMyRoom, setIsMyRoom] = React.useState(false);
+  const appliedStatus = room?.appliedStatus || state?.appliedStatus;
+  const isClosed = state?.closed ?? room?.recruiting === false;
+  const isApplied = ['WAITING', 'waiting'].includes(appliedStatus);
+  const isAccepted = ['APPROVED', 'accepted'].includes(appliedStatus);
+
+  React.useEffect(() => {
+    let mounted = true;
+    setRoomLoading(true);
+    setRoomError('');
+    loadRoomDetail(id)
+      .then((detail) => {
+        if (!mounted) return;
+        if (!detail || typeof detail !== 'object') {
+          throw new TypeError('Room detail response must be an object');
+        }
+        const normalized = normalizeRoom(detail);
+        setRoom(normalized);
+        setBookmarked(Boolean(detail?.liked));
+        setIsMyRoom(Boolean(detail?.isMyRoom));
+        if (typeof window !== 'undefined') {
+          window.sessionStorage.setItem(ROOM_DETAIL_CACHE_KEY, JSON.stringify(normalized));
+        }
+      })
+      .catch((e) => {
+        if (mounted && !initialRoom) setRoomError(e?.message || '모집방 정보를 불러오지 못했어요.');
+      })
+      .finally(() => { if (mounted) setRoomLoading(false); });
+    return () => { mounted = false; };
+  }, [id]);
 
   React.useEffect(() => {
     let mounted = true;
@@ -879,7 +931,7 @@ export function RoomDetailScreen() {
       .then(([roomRule, myChecklist, myRoom]) => {
         if (!mounted) return;
         setChecklist(compareChecklists(roomRule, myChecklist));
-        setIsMyRoom(myRoom?.roomNo === id);
+        setIsMyRoom((current) => current || myRoom?.roomNo === id);
       })
       .catch(() => {
         if (mounted) setChecklistError(true);
@@ -926,6 +978,8 @@ export function RoomDetailScreen() {
         <div style={{ padding: '8px 20px 16px' }}>
           <h1 style={{ margin: 0, fontSize: 24, fontWeight: 700, letterSpacing: '-0.5px', lineHeight: 1.3, fontFamily: 'var(--font-sans)' }}>{room?.title || '모집방 상세'}</h1>
           {roomMeta && <div style={{ fontSize: 14, color: 'var(--ink-3)', marginTop: 6 }}>{roomMeta}</div>}
+          {roomLoading && <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 8 }}>모집방 정보를 불러오고 있어요.</div>}
+          {roomError && <div style={{ fontSize: 12, color: 'var(--danger)', marginTop: 8 }}>{roomError}</div>}
         </div>
 
         {/* Match summary — derived from checklist comparison */}

--- a/src/shared/api/auth.js
+++ b/src/shared/api/auth.js
@@ -56,6 +56,17 @@ export async function logout() {
   }
 }
 
+export async function deleteAccount(reason) {
+  try {
+    await apiRequestWithAuth('/api/users/me', {
+      method: 'DELETE',
+      body: reason ? { reason } : {},
+    });
+  } finally {
+    clearProfileCache();
+  }
+}
+
 export async function sendVerificationEmail(email) {
   await apiRequest(`/api/email/send?email=${encodeURIComponent(email)}`, {
     method: 'POST',

--- a/src/shared/api/client.js
+++ b/src/shared/api/client.js
@@ -40,6 +40,7 @@ export async function apiRequest(path, options = {}) {
     credentials: 'include',
   });
   const body = await parseResponseBody(response);
+  const contentType = response.headers.get('Content-Type') || '';
 
   if (!response.ok) {
     const message = typeof body === 'object' && body?.message
@@ -49,6 +50,12 @@ export async function apiRequest(path, options = {}) {
       status: response.status,
       code: typeof body === 'object' ? body?.code : undefined,
       details: typeof body === 'object' ? body?.details : undefined,
+    });
+  }
+
+  if (typeof body === 'string' && contentType.includes('text/html')) {
+    throw new ApiError('API 응답이 올바르지 않습니다.', {
+      status: response.status,
     });
   }
 

--- a/src/shared/api/client.test.js
+++ b/src/shared/api/client.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { apiRequest, ApiError } from './client';
+
+describe('api client', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('JSON 응답을 반환한다', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(
+      JSON.stringify({ ok: true }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ))));
+
+    await expect(apiRequest('/api/test')).resolves.toEqual({ ok: true });
+  });
+
+  it('Vite HTML fallback 200 응답은 API 성공으로 처리하지 않는다', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(
+      '<!doctype html><div id="root"></div>',
+      { status: 200, headers: { 'Content-Type': 'text/html' } },
+    ))));
+
+    await expect(apiRequest('/api/test')).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/src/shared/api/home.js
+++ b/src/shared/api/home.js
@@ -8,6 +8,10 @@ export function loadNotices() {
   return apiRequest('/api/notices');
 }
 
+export function loadNoticeDetail(noticeNo) {
+  return apiRequest(`/api/notices/${encodeURIComponent(noticeNo)}`);
+}
+
 export function loadCalendarEvents(startDate, endDate) {
   const params = new URLSearchParams({ startDate, endDate });
   return apiRequest(`/api/calendar/events?${params.toString()}`);
@@ -33,11 +37,26 @@ export function registerNotificationDevice(deviceId, fcmToken = null) {
   });
 }
 
+export function loadNotificationSettings() {
+  return apiRequestWithAuth('/api/users/me/notification-settings');
+}
+
+export function updateNotificationSettings(settings) {
+  return apiRequestWithAuth('/api/users/me/notification-settings', {
+    method: 'PUT',
+    body: settings,
+  });
+}
+
 export function findRooms(filter) {
   return apiRequestWithAuth('/api/rooms/search', {
     method: 'POST',
     body: filter,
   });
+}
+
+export function loadRoomDetail(roomNo) {
+  return apiRequestWithAuth(`/api/rooms/${encodeURIComponent(roomNo)}`);
 }
 
 export function loadRoomRule(roomNo) {

--- a/src/shared/api/home.test.js
+++ b/src/shared/api/home.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  loadNoticeDetail,
+  loadNotificationSettings,
+  updateNotificationSettings,
+  loadRoomDetail,
+} from './home';
+import { apiRequest, apiRequestWithAuth } from './client';
+
+vi.mock('./client', () => ({
+  apiRequest: vi.fn(() => Promise.resolve('OK')),
+  apiRequestWithAuth: vi.fn(() => Promise.resolve('OK')),
+}));
+
+describe('home api', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loadNoticeDetail은 GET /api/notices/{noticeNo} 호출', async () => {
+    await loadNoticeDetail('notice 1');
+    expect(apiRequest).toHaveBeenCalledWith('/api/notices/notice%201');
+  });
+
+  it('loadNotificationSettings는 GET notification-settings 호출', async () => {
+    await loadNotificationSettings();
+    expect(apiRequestWithAuth).toHaveBeenCalledWith('/api/users/me/notification-settings');
+  });
+
+  it('updateNotificationSettings는 PUT notification-settings 호출', async () => {
+    const settings = { enabled: true, applicants: true, applicantResult: true, chat: true, notice: true, schedule: false };
+    await updateNotificationSettings(settings);
+    expect(apiRequestWithAuth).toHaveBeenCalledWith('/api/users/me/notification-settings', {
+      method: 'PUT',
+      body: settings,
+    });
+  });
+
+  it('loadRoomDetail은 GET /api/rooms/{roomNo} 호출', async () => {
+    await loadRoomDetail('room 1');
+    expect(apiRequestWithAuth).toHaveBeenCalledWith('/api/rooms/room%201');
+  });
+});

--- a/src/shared/api/room.js
+++ b/src/shared/api/room.js
@@ -51,6 +51,10 @@ export function loadMyRoommates() {
   return client.apiRequestWithAuth('/api/rooms/me/roommates');
 }
 
+export function loadRoommateHistory() {
+  return client.apiRequestWithAuth('/api/users/me/roommate-history');
+}
+
 export function cancelRoomApplication(roomNo) {
   return client.apiRequestWithAuth(`/api/rooms/${roomNo}/request`, {
     method: 'DELETE',

--- a/src/shared/api/room.test.js
+++ b/src/shared/api/room.test.js
@@ -10,6 +10,7 @@ import {
   loadMyRoommates,
   updateRoomTitle,
   createRoom,
+  loadRoommateHistory,
 } from './room';
 
 describe('room api', () => {
@@ -79,6 +80,11 @@ describe('room api', () => {
     const result = await loadMyRoommates();
     expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/rooms/me/roommates');
     expect(result).toEqual(mockList);
+  });
+
+  it('loadRoommateHistory는 GET /api/users/me/roommate-history 호출', async () => {
+    await loadRoommateHistory();
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/users/me/roommate-history');
   });
 
   it('updateRoomTitle은 PUT /api/rooms/me/title?roomNo=42 호출', async () => {

--- a/src/shared/api/support.js
+++ b/src/shared/api/support.js
@@ -1,0 +1,16 @@
+import * as client from './client';
+
+export function createSupportInquiry(request) {
+  return client.apiRequestWithAuth('/api/support/inquiries', {
+    method: 'POST',
+    body: request,
+  });
+}
+
+export function loadSupportInquiries() {
+  return client.apiRequestWithAuth('/api/support/inquiries');
+}
+
+export function loadSupportInquiry(inquiryNo) {
+  return client.apiRequestWithAuth(`/api/support/inquiries/${encodeURIComponent(inquiryNo)}`);
+}

--- a/src/shared/api/support.test.js
+++ b/src/shared/api/support.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as client from './client';
+import { createSupportInquiry, loadSupportInquiries, loadSupportInquiry } from './support';
+
+describe('support api', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(client, 'apiRequestWithAuth').mockResolvedValue('OK');
+  });
+
+  it('createSupportInquiry는 POST /api/support/inquiries 호출', async () => {
+    const request = { category: 'APP_USAGE', message: '문의합니다' };
+    await createSupportInquiry(request);
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/support/inquiries', {
+      method: 'POST',
+      body: request,
+    });
+  });
+
+  it('loadSupportInquiries는 GET /api/support/inquiries 호출', async () => {
+    await loadSupportInquiries();
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/support/inquiries');
+  });
+
+  it('loadSupportInquiry는 inquiryNo를 인코딩해 호출', async () => {
+    await loadSupportInquiry('inq 1');
+    expect(client.apiRequestWithAuth).toHaveBeenCalledWith('/api/support/inquiries/inq%201');
+  });
+});


### PR DESCRIPTION
## 📌 제목
> **누락 API 프론트 연동**

---

## 📢 요약
> **백엔드에 추가된 API를 프론트 화면에 연결하고 UI QA 중 발견한 API 응답 처리 문제를 보완했습니다.**
> - 알림 설정, 계정 탈퇴, 고객 문의, 방 상세, 공지 상세, 방 검색 keyword, 룸메이트 기록 API를 실제 화면에 연동했습니다.
> - Vite dev fallback HTML 응답이 API 성공처럼 처리되는 문제를 방어했습니다.
> - 준비 중 문구를 제거하고 실제 로딩/저장/오류 상태로 표시되도록 수정했습니다.

🔗 **연관 이슈**: Resolves #이슈번호

---

## 🚀 PR 유형
> **해당하는 항목에 체크해주세요.**

- [x] ✨ 새로운 기능 추가
- [x] 🐛 버그 수정
- [ ] 🎨 CSS/UI 디자인 변경
- [ ] 🔧 코드에 영향 없는 변경(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 🔨 코드 리팩토링
- [ ] 📝 주석 추가 및 수정
- [ ] 📄 문서 수정
- [x] 🧪 테스트 추가 또는 리팩토링
- [ ] 🏗️ 빌드 및 패키지 매니저 수정
- [ ] 📂 파일 또는 폴더명 수정
- [ ] 🗑️ 파일 또는 폴더 삭제

---

## ✅ PR 체크리스트
> **PR이 다음 요구 사항을 충족하는지 확인해주세요.**

- [x] 🔹 커밋 메시지 컨벤션을 준수했습니다. ([Commit message convention 참고](#))
- [x] 🔹 변경 사항에 대한 테스트를 수행했습니다. (버그 수정/기능 테스트)
- [ ] 🔹 관련 문서를 업데이트했습니다. (필요한 경우)

---

## 📜 기타
> **리뷰어가 알면 좋을 추가 사항을 적어주세요.**
> - 검증: `npm test`, `npm run build`, BE `./gradlew test`
> - UI QA: 모바일 viewport 기준 주요 화면 smoke test 진행
> - 로컬 FE에서 `VITE_API_BASE_URL`이 비어 있으면 실제 BE 네트워크 E2E가 아니라 UI/연동 코드 검증으로만 동작합니다.
> - `npm run build`에서 500KB chunk size warning이 표시되지만 빌드는 성공합니다.
